### PR TITLE
Consolidate and clean up JSON-LD

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ The SEO tag will respect any of the following if included in your site's `_confi
 
 * `logo` - Relative URL to a site-wide logo (e.g., `assets/your-company-logo.png`)
 * `social` - For [specifying social profiles](https://developers.google.com/structured-data/customize/social-profiles). The following properties are available:
-  * `type` - Either `person` or `organization` (defaults to `person`)
   * `name` - If the user or organization name differs from the site's name
   * `links` - An array of links to social media profiles.
 * `google_site_verification` for verifying ownership via Google webmaster tools
@@ -145,3 +144,12 @@ There are several ways to convey this author-specific information. Author inform
   ```yml
   author: benbalter
   ```
+
+### Customizing JSON-LD output
+
+The following options can be set for any particular page. While the default options are meant to serve most users in the most common circumstances, there may be situations where more precise control is necessary.
+
+* `seo`
+  * `name` - If the name of the thing that the page represents is different from the page title. (i.e.: "Frank's Café" vs "Welcome to Frank's Café")
+  * `type` - The type of things that the page represents. This must be a [Schema.org type](http://schema.org/docs/schemas.html), and will probably usually be something like [`BlogPosting`](http://schema.org/BlogPosting), [`NewsArticle`](http://schema.org/NewsArticle), [`Person`](http://schema.org/Person), [`Organization`](http://schema.org/Organization), etc.
+  * `links` - An array of other URLs that represent the same thing that this page represents. For instance, Jane's bio page might include links to Jane's GitHub and Twitter profiles.

--- a/lib/template.html
+++ b/lib/template.html
@@ -1,5 +1,9 @@
 <!-- Begin Jekyll SEO tag v{{ seo_tag.version }} -->
 
+{% if page.url == "/" or page.url == "/about/" %}
+  {% assign seo_homepage_or_about = true %}
+{% endif %}
+
 {% if site.url %}
   {% assign seo_url = site.url | append: site.baseurl %}
 {% endif %}
@@ -20,6 +24,17 @@
   {% if site.description %}
     {% assign seo_title = seo_title | append:" - " | append: site.description %}
   {% endif %}
+{% endif %}
+
+{% if page.seo and page.seo.name %}
+    {% assign seo_name = page.seo.name %}
+{% elsif seo_homepage_or_about and site.social and site.social.name %}
+    {% assign seo_name = site.social.name %}
+{% elsif seo_homepage_or_about and seo_site_title %}
+    {% assign seo_name = seo_site_title %}
+{% endif %}
+{% if seo_name %}
+  {% assign seo_name = seo_name | markdownify | strip_html | strip_newlines | escape_once %}
 {% endif %}
 
 {% if seo_title %}
@@ -51,6 +66,22 @@
     {% endif %}
   {% endif %}
   {% assign seo_author_twitter = seo_author_twitter | replace:"@","" %}
+{% endif %}
+
+{% if page.seo and page.seo.type %}
+    {% assign seo_type = page.seo.type %}
+{% elsif seo_homepage_or_about %}
+    {% assign seo_type = "WebSite" %}
+{% elsif page.date %}
+    {% assign seo_type = "BlogPosting" %}
+{% else %}
+    {% assign seo_type = "WebPage" %}
+{% endif %}
+
+{% if page.seo and page.seo.links %}
+    {% assign seo_links = page.seo.links %}
+{% elsif seo_homepage_or_about and site.social and site.social.links %}
+    {% assign seo_links = site.social.links %}
 {% endif %}
 
 {% if seo_tag.title and seo_title %}
@@ -125,22 +156,12 @@
   {
     "@context" : "http://schema.org",
 
-{% if page.seo and page.seo.type %}
-    "@type" : {{ page.seo.type | jsonify }},
-{% elsif page.url == "/" %}
-    "@type" : "WebSite",
-{% elsif page.date %}
-    "@type" : "BlogPosting",
-{% else %}
-    "@type" : "WebPage",
+{% if seo_type %}
+    "@type" : {{ seo_type | jsonify }},
 {% endif %}
 
-{% if page.seo and page.seo.name %}
-    "name" : {{ page.seo.name | jsonify }},
-{% elsif page.url == "/" and site.social and site.social.name %}
-    "name" : {{ site.social.name | jsonify }},
-{% elsif page.url == "/" and seo_site_title %}
-    "name" : {{ seo_site_title | jsonify }},
+{% if seo_name %}
+    "name" : {{ seo_name | jsonify }},
 {% endif %}
 
 {% if seo_page_title %}
@@ -163,10 +184,8 @@
     "logo": {{ site.logo | prepend: "/" | prepend: seo_url | jsonify }},
 {% endif %}
 
-{% if page.seo and page.seo.links %}
-    "sameAs" : {{ page.seo.links | jsonify }},
-{% elsif (page.url == "/" or page.url == "/about/") and site.social and site.social.links %}
-    "sameAs" : {{ site.social.links | jsonify }},
+{% if seo_links %}
+    "sameAs" : {{ seo_links | jsonify }},
 {% endif %}
 
     "url" : "{{ page.url | prepend: seo_url | replace:'/index.html','/' }}"

--- a/lib/template.html
+++ b/lib/template.html
@@ -155,8 +155,8 @@
     "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
 {% endif %}
 
-{% if page.description %}
-    "description": {{ page.description | jsonify }},
+{% if seo_description %}
+    "description": {{ seo_description | jsonify }},
 {% endif %}
 
 {% if site.logo %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -165,7 +165,7 @@
 
 {% if page.seo and page.seo.links %}
     "sameAs" : {{ page.seo.links | jsonify }},
-{% elsif page.url == "/" and site.social and site.social.links %}
+{% elsif (page.url == "/" or page.url == "/about/") and site.social and site.social.links %}
     "sameAs" : {{ site.social.links | jsonify }},
 {% endif %}
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -73,14 +73,6 @@
 
 {% if seo_site_title %}
   <meta property="og:site_name" content="{{ seo_site_title }}" />
-  <script type="application/ld+json">
-    {
-      "@context" : "http://schema.org",
-      "@type" : "WebSite",
-      "name" : {{ seo_site_title | jsonify }},
-      "url" : {{ seo_url | jsonify }}
-    }
-  </script>
 {% endif %}
 
 {% if page.image %}
@@ -98,17 +90,6 @@
   {% if page.previous.url %}
     <link rel="prev" href="{{ page.previous.url | prepend: seo_url | replace:'/index.html','/' }}" title="{{ page.previous.title | escape }}" />
   {% endif %}
-
-  <script type="application/ld+json">
-    {
-      "@context": "http://schema.org",
-      "@type": "NewsArticle",
-      "headline": {{ page.title | jsonify }},
-      "image": {{ page.image | jsonify }},
-      "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
-      "description": {{ seo_description | jsonify }}
-    }
-  </script>
 {% endif %}
 
 {% if site.twitter %}
@@ -140,27 +121,56 @@
   <meta name="google-site-verification" content="{{ site.google_site_verification }}" />
 {% endif %}
 
-{% if site.logo %}
-  <script type="application/ld+json">
-    {
-      "@context": "http://schema.org",
-      "@type": "Organization",
-      "url": {{ seo_url | jsonify }},
-      "logo": {{ site.logo | prepend: "/" | prepend: seo_url | jsonify }}
-    }
-  </script>
+<script type="application/ld+json">
+  {
+    "@context" : "http://schema.org",
+
+{% if page.seo and page.seo.type %}
+    "@type" : {{ page.seo.type | jsonify }},
+{% elsif page.url == "/" %}
+    "@type" : "WebSite",
+{% elsif page.date %}
+    "@type" : "BlogPosting",
+{% else %}
+    "@type" : "WebPage",
 {% endif %}
 
-{% if site.social %}
-  <script type="application/ld+json">
-    {
-      "@context" : "http://schema.org",
-      "@type" : "{% if site.social.type %}{{ site.social.type }}{% else %}person{% endif %}",
-      "name" : "{% if site.social.name %}{{ site.social.name }}{% else %}{{ seo_site_title }}{% endif %}",
-      "url" : {{ seo_url | jsonify }},
-      "sameAs" : {{ site.social.links | jsonify }}
-    }
-  </script>
+{% if page.seo and page.seo.name %}
+    "name" : {{ page.seo.name | jsonify }},
+{% elsif page.url == "/" and site.social and site.social.name %}
+    "name" : {{ site.social.name | jsonify }},
+{% elsif page.url == "/" and seo_site_title %}
+    "name" : {{ seo_site_title | jsonify }},
 {% endif %}
+
+{% if seo_page_title %}
+    "headline": {{ seo_page_title | jsonify }},
+{% endif %}
+
+{% if page.image %}
+    "image": {{ page.image | jsonify }},
+{% endif %}
+
+{% if page.date %}
+    "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
+{% endif %}
+
+{% if page.description %}
+    "description": {{ page.description | jsonify }},
+{% endif %}
+
+{% if site.logo %}
+    "logo": {{ site.logo | prepend: "/" | prepend: seo_url | jsonify }},
+{% endif %}
+
+{% if page.seo and page.seo.links %}
+    "sameAs" : {{ page.seo.links | jsonify }},
+{% elsif page.url == "/" and site.social and site.social.links %}
+    "sameAs" : {{ site.social.links | jsonify }},
+{% endif %}
+
+    "url" : "{{ page.url | prepend: seo_url | replace:'/index.html','/' }}"
+  }
+</script>
 
 <!-- End Jekyll SEO tag -->

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -124,7 +124,6 @@ describe Jekyll::SeoTag do
 
       it 'outputs the logo' do
         expect(json_data['logo']).to eql('http://example.invalid/logo.png')
-        expect(json_data['url']).to eql('http://example.invalid')
       end
     end
 
@@ -133,8 +132,6 @@ describe Jekyll::SeoTag do
 
       it 'outputs the site title meta' do
         expect(output).to match(%r{<meta property="og:site_name" content="Foo" />})
-        expect(json_data['name']).to eql('Foo')
-        expect(json_data['url']).to eql('http://example.invalid')
       end
     end
   end
@@ -254,6 +251,15 @@ describe Jekyll::SeoTag do
     let(:links) { ['http://foo.invalid', 'http://bar.invalid'] }
     let(:social_namespace) { { 'name' => 'Ben', 'links' => links } }
     let(:site) { make_site('social' => social_namespace) }
+    let(:meta) do
+      {
+        'permalink'   => '/',
+        'seo'         => {
+          'type' => 'person'
+        }
+      }
+    end
+    let(:page) { make_post(meta) }
 
     it 'outputs social meta' do
       expect(json_data['@type']).to eql('person')

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -251,20 +251,39 @@ describe Jekyll::SeoTag do
     let(:links) { ['http://foo.invalid', 'http://bar.invalid'] }
     let(:social_namespace) { { 'name' => 'Ben', 'links' => links } }
     let(:site) { make_site('social' => social_namespace) }
-    let(:meta) do
-      {
-        'permalink'   => '/',
-        'seo'         => {
-          'type' => 'person'
-        }
-      }
-    end
     let(:page) { make_post(meta) }
 
-    it 'outputs social meta' do
-      expect(json_data['@type']).to eql('person')
-      expect(json_data['name']).to eql('Ben')
-      expect(json_data['sameAs']).to eql(links)
+    context 'on homepage' do
+      let(:meta) do
+        {
+          'permalink'   => '/',
+          'seo'         => {
+            'type' => 'person'
+          }
+        }
+      end
+
+      it 'outputs social meta' do
+        expect(json_data['@type']).to eql('person')
+        expect(json_data['name']).to eql('Ben')
+        expect(json_data['sameAs']).to eql(links)
+      end
+    end
+
+    context 'on about page' do
+      let(:meta) { { 'permalink' => '/about/' } }
+
+      it 'outputs sameAs links' do
+        expect(json_data['sameAs']).to eql(links)
+      end
+    end
+
+    context 'on other pages' do
+      let(:meta) { { 'permalink' => '/2/' } }
+
+      it 'does not output sameAs links' do
+        expect(json_data['sameAs']).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Move all JSON-LD tests into one section
- [x] Consolidate all JSON-LD `<script>` tags into just one block
- [x] Modify the way `@type` is decided for a page
  - [x] Decide on a default `@type` (Maybe different for home vs. post pages?)
  - [x] Provide a sensible way to override the default `@type`
  - [x] Document all changes