### PR TITLE
Update twitter:image to output full url

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The SEO tag will respect any of the following if included in your site's `_confi
      publisher: 1234
    ```
 
-* `logo` - Relative URL to a site-wide logo (e.g., `assets/your-company-logo.png`)
+* `logo` - Relative URL to a site-wide logo (e.g., `/assets/your-company-logo.png`)
 * `social` - For [specifying social profiles](https://developers.google.com/structured-data/customize/social-profiles). The following properties are available:
   * `type` - Either `person` or `organization` (defaults to `person`)
   * `name` - If the user or organization name differs from the site's name
@@ -79,7 +79,7 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 
 * `title` - The title of the post, page, or document
 * `description` - A short description of the page's content
-* `image` - Relative URL to an image associated with the post, page, or document (e.g., `assets/page-pic.jpg`)
+* `image` - Relative URL to an image associated with the post, page, or document (e.g., `/assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see below)
 
 ### Disabling `<title>` output

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Jekyll plugin to add metadata tags for search engines and social networks to better index and display your site's content.
 
-[![Gem Version](https://badge.fury.io/rb/jekyll-seo-tag.svg)](https://badge.fury.io/rb/jekyll-seo-tag) [![Build Status](https://travis-ci.org/benbalter/jekyll-seo-tag.svg)](https://travis-ci.org/benbalter/jekyll-seo-tag)
+[![Gem Version](https://badge.fury.io/rb/jekyll-seo-tag.svg)](https://badge.fury.io/rb/jekyll-seo-tag) [![Build Status](https://travis-ci.org/jekyll/jekyll-seo-tag.svg)](https://travis-ci.org/jekyll/jekyll-seo-tag)
 
 ## What it does
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -118,7 +118,7 @@
   <meta name="twitter:description" content="{{ seo_description }}" />
 
   {% if page.image %}
-    <meta name="twitter:image" content="{{ page.image | prepend: "/" | prepend: seo_url | escape }}" />
+    <meta name="twitter:image" content="{{ page.image | prepend: seo_url | escape }}" />
   {% endif %}
 
   {% if seo_author_twitter %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -118,7 +118,7 @@
   <meta name="twitter:description" content="{{ seo_description }}" />
 
   {% if page.image %}
-    <meta name="twitter:image" content="{{ page.image | escape }}" />
+    <meta name="twitter:image" content="{{ page.image | prepend: "/" | prepend: seo_url | escape }}" />
   {% endif %}
 
   {% if seo_author_twitter %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -84,7 +84,7 @@
 {% endif %}
 
 {% if page.image %}
-  <meta property="og:image" content="{{ page.image | prepend: "/" | prepend: seo_url | escape }}" />
+  <meta property="og:image" content="{{ page.image | prepend: seo_url | escape }}" />
 {% endif %}
 
 {% if page.date %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -247,6 +247,16 @@ describe Jekyll::SeoTag do
           expect(output).to match(expected)
         end
       end
+
+      context 'with page.image' do
+        let(:site) { make_site('twitter' => site_twitter, 'url' => 'http://example.invalid') }
+        let(:page) { make_page('image' => 'foo.png') }
+
+        it 'outputs the image' do
+          expected = %r{<meta name="twitter:image" content="http://example.invalid/foo.png" />}
+          expect(output).to match(expected)
+        end
+      end
     end
   end
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -250,10 +250,10 @@ describe Jekyll::SeoTag do
 
       context 'with page.image' do
         let(:site) { make_site('twitter' => site_twitter, 'url' => 'http://example.invalid') }
-        let(:page) { make_page('image' => 'foo.png') }
+        let(:page) { make_page('image' => '/img/foo.png') }
 
         it 'outputs the image' do
-          expected = %r{<meta name="twitter:image" content="http://example.invalid/foo.png" />}
+          expected = %r{<meta name="twitter:image" content="http://example.invalid/img/foo.png" />}
           expect(output).to match(expected)
         end
       end

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -111,10 +111,10 @@ describe Jekyll::SeoTag do
     end
 
     context 'with page.image' do
-      let(:page) { make_page('image' => 'foo.png') }
+      let(:page) { make_page('image' => '/img/foo.png') }
 
       it 'outputs the image' do
-        expected = %r{<meta property="og:image" content="http://example.invalid/foo.png" />}
+        expected = %r{<meta property="og:image" content="http://example.invalid/img/foo.png" />}
         expect(output).to match(expected)
       end
     end


### PR DESCRIPTION
Oops - I should have updated the twitter image in https://github.com/jekyll/jekyll-seo-tag/pull/44 Now it matches behavior of og:image.