### PR TITLE
Fix og:title condition and remove redundant tags

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -126,12 +126,6 @@
 {% if site.twitter %}
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@{{ site.twitter.username | replace:"@","" }}" />
-  <meta name="twitter:title" content="{{ seo_title }}" />
-  <meta name="twitter:description" content="{{ seo_description }}" />
-
-  {% if page.image %}
-    <meta name="twitter:image" content="{{ page.image | prepend: seo_url | escape }}" />
-  {% endif %}
 
   {% if seo_author_twitter %}
     <meta name="twitter:creator" content="@{{ seo_author_twitter }}" />

--- a/lib/template.html
+++ b/lib/template.html
@@ -88,7 +88,7 @@
   <title>{{ seo_title }}</title>
 {% endif %}
 
-{% if seo_title %}
+{% if seo_page_title %}
   <meta property="og:title" content="{{ seo_page_title }}" />
 {% endif %}
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -266,16 +266,6 @@ EOS
           expect(output).to match(expected)
         end
       end
-
-      context 'with page.image' do
-        let(:site) { make_site('twitter' => site_twitter, 'url' => 'http://example.invalid') }
-        let(:page) { make_page('image' => '/img/foo.png') }
-
-        it 'outputs the image' do
-          expected = %r{<meta name="twitter:image" content="http://example.invalid/img/foo.png" />}
-          expect(output).to match(expected)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
In investigating #64, I learned that:

 1. We were not checking for `seo_page_title` properly
 2. We [do not need to repeat Open Graph tags just for Twitter](https://dev.twitter.com/cards/getting-started#opengraph)