### PR TITLE
jsonify page.url instead of using quotes

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -182,7 +182,7 @@
     "sameAs": {{ seo_links | jsonify }},
 {% endif %}
 
-    "url": "{{ page.url | prepend: seo_url | replace:'/index.html','/' }}"
+    "url": {{ page.url | prepend: seo_url | replace:'/index.html','/' | jsonify }}
   }
 </script>
 


### PR DESCRIPTION
Only for consistency with the rest of the JSON-LD block