### PR TITLE
Facebook admins meta tag and Facebook options spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ The SEO tag will respect any of the following if included in your site's `_confi
     username: benbalter
   ```
 
-* `facebook:app_id` (a Facebook app ID for Facebook insights), and/or `facebook:publisher` (a Facebook page URL or ID of the publishing entity). You'll want to describe one or both like so:
+* `facebook:app_id` (a Facebook app ID for Facebook insights), `facebook:publisher` (a Facebook page URL or ID of the publishing entity) and/or `facebook:admins`
+  (a Facebook user ID for domain insights linked to a personal account). You'll want to describe one or both like so:
 
    ```yml
   facebook:
     app_id: 1234
     publisher: 1234
+    admins: 1234
    ```
 
 * `logo` - URL to a site-wide logo (e.g., `/assets/your-company-logo.png`)

--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ The SEO tag will respect any of the following if included in your site's `_confi
     username: benbalter
   ```
 
-* `facebook:app_id` (a Facebook app ID for Facebook insights), `facebook:publisher` (a Facebook page URL or ID of the publishing entity) and/or `facebook:admins`
-  (a Facebook user ID for domain insights linked to a personal account). You'll want to describe one or both like so:
+* `facebook` - The following properties are available:
+  * `facebook:app_id` - a Facebook app ID for Facebook insights
+  * `facebook:publisher` - a Facebook page URL or ID of the publishing entity
+  * `facebook:admins` - a Facebook user ID for domain insights linked to a personal account
+
+  You'll want to describe one or more like so:
 
    ```yml
   facebook:

--- a/lib/template.html
+++ b/lib/template.html
@@ -164,6 +164,10 @@
 {% endif %}
 
 {% if site.facebook %}
+  {% if site.facebook.admins %}
+    <meta property="fb:admins" content="{{ site.facebook.admins }}" />
+  {% endif %}
+
   {% if site.facebook.publisher %}
     <meta property="article:publisher" content="{{ site.facebook.publisher }}" />
   {% endif %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -252,6 +252,33 @@ EOS
     end
   end
 
+  context 'facebook' do
+    let(:site_facebook) do
+      {
+        'admins' => 'jekyllrb-fb-admins',
+        'app_id' => 'jekyllrb-fb-app_id',
+        'publisher' => 'jekyllrb-fb-publisher'
+      }
+    end
+
+    let(:site) { make_site('facebook' => site_facebook) }
+
+    it 'outputs facebook admins meta' do
+      expected = %r{<meta property="fb:admins" content="jekyllrb-fb-admins" />}
+      expect(output).to match(expected)
+    end
+
+    it 'outputs facebook app ID meta' do
+      expected = %r{<meta property="fb:app_id" content="jekyllrb-fb-app_id" />}
+      expect(output).to match(expected)
+    end
+
+    it 'outputs facebook article publisher meta' do
+      expected = %r{<meta property="article:publisher" content="jekyllrb-fb-publisher" />}
+      expect(output).to match(expected)
+    end
+  end
+
   context 'twitter' do
     context 'with site.twitter.username' do
       let(:site_twitter) { { 'username' => 'jekyllrb' } }


### PR DESCRIPTION
[Domain insights](https://www.facebook.com/insights) from facebook linked to a personal account work with

```html
<meta property="fb:admins" content="{{ facebook id }}" />
```

Added a spec for all the facebook options too.