### PR TITLE
Different philosophy for rel prev/next links based on recommendations from Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Jekyll SEO Tag adds the following meta tags to your site:
 * Pages title (with site title appended when available)
 * Page description
 * Canonical URL
-* Next and previous URLs for posts
+* Next and previous URLs on paginated pages
 * [JSON-LD Site and post metadata](https://developers.google.com/structured-data/) for richer indexing
 * [Open graph](http://ogp.me/) title, description, site title, and URL (for Facebook, LinkedIn, etc.)
 * [Twitter summary card](https://dev.twitter.com/cards/overview) metadata

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -30,6 +30,7 @@ module Jekyll
       {
         'page'    => context.registers[:page],
         'site'    => context.registers[:site].site_payload['site'],
+        'paginator' => context['paginator'],
         'seo_tag' => options
       }
     end

--- a/lib/template.html
+++ b/lib/template.html
@@ -139,14 +139,13 @@
 {% if page.date %}
   <meta property="og:type" content="article" />
   <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
+{% endif %}
 
-  {% if page.next.url %}
-    <link rel="next" href="{{ page.next.url | prepend: seo_url | replace:'/index.html','/' }}" title="{{ page.next.title | escape }}" />
-  {% endif %}
-
-  {% if page.previous.url %}
-    <link rel="prev" href="{{ page.previous.url | prepend: seo_url | replace:'/index.html','/' }}" title="{{ page.previous.title | escape }}" />
-  {% endif %}
+{% if paginator.previous_page %}
+  <link rel="prev" href="{{ paginator.previous_page_path | prepend: seo_url }}">
+{% endif %}
+{% if paginator.next_page %}
+  <link rel="next" href="{{ paginator.next_page_path | prepend: seo_url }}">
 {% endif %}
 
 {% if site.twitter %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -446,7 +446,7 @@ EOS
   end
 
   context 'with pagination' do
-    let(:context) { make_context(environments: { 'paginator' => paginator }) }
+    let(:context) { make_context({}, { 'paginator' => paginator }) }
 
     it 'outputs pagination links' do
       expect(output).to match(%r{<link rel="prev" href="foo">})

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -446,11 +446,11 @@ EOS
   end
 
   context 'with pagination' do
-    let(:context) { make_context({}, { 'paginator' => paginator }) }
+    let(:context) { make_context({}, 'paginator' => paginator) }
 
     it 'outputs pagination links' do
-      expect(output).to match(%r{<link rel="prev" href="foo">})
-      expect(output).to match(%r{<link rel="next" href="bar">})
+      expect(output).to match(/<link rel="prev" href="foo">/)
+      expect(output).to match(/<link rel="next" href="bar">/)
     end
   end
 end

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -10,6 +10,7 @@ describe Jekyll::SeoTag do
   let(:output)    { Liquid::Template.parse("{% #{tag} #{text} %}").render!(context, {}) }
   let(:json)      { output.match(%r{<script type=\"application/ld\+json\">(.*)</script>}m)[1] }
   let(:json_data) { JSON.parse(json) }
+  let(:paginator) { { 'previous_page' => true, 'previous_page_path' => 'foo', 'next_page' => true, 'next_page_path' => 'bar' } }
 
   before do
     Jekyll.logger.log_level = :error
@@ -441,6 +442,15 @@ EOS
 
     it 'does not output a <title> tag' do
       expect(output).not_to match(/<title>/)
+    end
+  end
+
+  context 'with pagination' do
+    let(:context) { make_context(environments: { 'paginator' => paginator }) }
+
+    it 'outputs pagination links' do
+      expect(output).to match(%r{<link rel="prev" href="foo">})
+      expect(output).to match(%r{<link rel="next" href="bar">})
     end
   end
 end

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -24,6 +24,16 @@ describe Jekyll::SeoTag do
     expect(output).to match(/Jekyll SEO tag v#{version}/i)
   end
 
+  it 'outputs valid HTML' do
+    site.process
+    options = {
+      check_html: true,
+      checks_to_ignore: %w(ScriptCheck LinkCheck ImageCheck)
+    }
+    status = HTML::Proofer.new(dest_dir, options).run
+    expect(status).to eql(true)
+  end
+
   context 'with page.title' do
     let(:page) { make_page('title' => 'foo') }
 
@@ -432,15 +442,5 @@ EOS
     it 'does not output a <title> tag' do
       expect(output).not_to match(/<title>/)
     end
-  end
-
-  it 'outputs valid HTML' do
-    site.process
-    options = {
-      check_html: true,
-      checks_to_ignore: %w(ScriptCheck LinkCheck ImageCheck)
-    }
-    status = HTML::Proofer.new(dest_dir, options).run
-    expect(status).to eql(true)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,6 @@ def make_site(options = {})
   Jekyll::Site.new(config)
 end
 
-def make_context(registers = {}, environments: {})
+def make_context(registers = {}, environments = {})
   Liquid::Context.new(environments, {}, { site: site, page: page }.merge(registers))
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,6 @@ def make_site(options = {})
   Jekyll::Site.new(config)
 end
 
-def make_context(registers = {})
-  Liquid::Context.new({}, {}, { site: site, page: page }.merge(registers))
+def make_context(registers = {}, environments: {})
+  Liquid::Context.new(environments, {}, { site: site, page: page }.merge(registers))
 end


### PR DESCRIPTION
Details here: https://webmasters.googleblog.com/2011/09/pagination-with-relnext-and-relprev.html.

This replaces the per-page prev/next links with general ones that will be output whenever there is a paginator with a previous or next page to show. I like the idea of leaning on the paginator to know when there is a previous or next page to link to.

Also resolves #80.