### PR TITLE
Use SmartyPants

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,7 @@ image:
   height: 100
   width: 100
 ```
+
+### SmartyPants Titles
+
+Titles will be processed using [Jekyll's `smartify` filter](https://jekyllrb.com/docs/templates/). This will use SmartyPants to translate plain ASCII punctuation into "smart" typographic punctuation. This will not render or strip any Markdown you may be using in a page title.

--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'jekyll', '~> 3.0'
+  spec.add_dependency 'jekyll', '~> 3.1'
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'

--- a/lib/template.html
+++ b/lib/template.html
@@ -34,19 +34,19 @@
     {% assign seo_name = seo_site_title %}
 {% endif %}
 {% if seo_name %}
-  {% assign seo_name = seo_name | markdownify | strip_html | strip_newlines | escape_once %}
+  {% assign seo_name = seo_name | smartify | strip_html | strip_newlines | escape_once %}
 {% endif %}
 
 {% if seo_title %}
-  {% assign seo_title = seo_title | markdownify | strip_html | strip_newlines | escape_once %}
+  {% assign seo_title = seo_title | smartify | strip_html | strip_newlines | escape_once | escape_once %}
 {% endif %}
 
 {% if seo_site_title %}
-  {% assign seo_site_title = seo_site_title | markdownify | strip_html | strip_newlines | escape_once %}
+  {% assign seo_site_title = seo_site_title | smartify | strip_html | strip_newlines | escape_once %}
 {% endif %}
 
 {% if seo_page_title %}
-  {% assign seo_page_title = seo_page_title | markdownify | strip_html | strip_newlines | escape_once %}
+  {% assign seo_page_title = seo_page_title | smartify | strip_html | strip_newlines | escape_once %}
 {% endif %}
 
 {% assign seo_description = page.description | default: page.excerpt | default: site.description %}


### PR DESCRIPTION
Fixes #17

Requires Jekyll 3.1

The `smartify` filter [includes Kramdown's `html_entity` parser](https://github.com/jekyll/jekyll/blob/v3.1.6/lib/jekyll/converters/smartypants.rb#L5) which will escape HTML for us. :+1: