### PR TITLE
Use image for twitter unless twitter specific image provided

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -130,6 +130,9 @@
   {% if page.image.width %}
     <meta property="og:image:width" content="{{ page.image.width }}" />
   {% endif %}
+  {% unless page.image.twitter %}
+    <meta name="twitter:image" content="{{ seo_page_image }}" />
+  {% endunless %}
 {% endif %}
 
 {% if page.image.twitter %}


### PR DESCRIPTION
If there is `seo_page_image` value, twitter card is `summary_large_image`, but the same time it is not providing tag for image

``` liquid
  {% if seo_page_image or page.image.twitter %}
    <meta name="twitter:card" content="summary_large_image" />
  {% else %}
    <meta name="twitter:card" content="summary" />
  {% endif %}
```
