### PR TITLE
Inherit Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
 Metrics/LineLength:
   Exclude:
     - spec/**/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ Style/Documentation:
 
 Style/FileName:
   Enabled: false
+
+AllCops:
+  Exclude:
+    - vendor/**/*

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -41,8 +41,8 @@ module Jekyll
 
     def info
       {
-        registers: context.registers,
-        filters: [Jekyll::Filters, JekyllSeoTag::Filters]
+        :registers => context.registers,
+        :filters => [Jekyll::Filters, JekyllSeoTag::Filters]
       }
     end
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -4,11 +4,11 @@ describe Jekyll::SeoTag do
   let(:page)      { make_page }
   let(:site)      { make_site }
   let(:post)      { make_post }
-  let(:context)   { make_context(page: page, site: site) }
+  let(:context)   { make_context(:page => page, :site => site) }
   let(:tag)       { 'seo' }
   let(:text)      { '' }
   let(:output)    { Liquid::Template.parse("{% #{tag} #{text} %}").render!(context, {}) }
-  let(:json)      { output.match(%r{<script type=\"application/ld\+json\">(.*)</script>}m)[1] }
+  let(:json)      { output.match(%r!<script type=\"application/ld\+json\">(.*)</script>!m)[1] }
   let(:json_data) { JSON.parse(json) }
   let(:paginator) { { 'previous_page' => true, 'previous_page_path' => 'foo', 'next_page' => true, 'next_page_path' => 'bar' } }
 
@@ -28,8 +28,8 @@ describe Jekyll::SeoTag do
   it 'outputs valid HTML' do
     site.process
     options = {
-      check_html: true,
-      checks_to_ignore: %w(ScriptCheck LinkCheck ImageCheck)
+      :check_html => true,
+      :checks_to_ignore => %w(ScriptCheck LinkCheck ImageCheck)
     }
     status = HTML::Proofer.new(dest_dir, options).run
     expect(status).to eql(true)
@@ -39,8 +39,8 @@ describe Jekyll::SeoTag do
     let(:page) { make_page('title' => 'foo') }
 
     it 'builds the title with a page title only' do
-      expect(output).to match(%r{<title>foo</title>})
-      expected = %r{<meta property="og:title" content="foo" />}
+      expect(output).to match(%r!<title>foo</title>!)
+      expected = %r!<meta property="og:title" content="foo" />!
       expect(output).to match(expected)
     end
 
@@ -48,7 +48,7 @@ describe Jekyll::SeoTag do
       let(:site) { make_site('title' => 'bar') }
 
       it 'builds the title with a page title and site title' do
-        expect(output).to match(%r{<title>foo - bar</title>})
+        expect(output).to match(%r!<title>foo - bar</title>!)
       end
     end
   end
@@ -57,7 +57,7 @@ describe Jekyll::SeoTag do
     let(:site) { make_site('title' => 'Site title') }
 
     it 'builds the title with only a site title' do
-      expect(output).to match(%r{<title>Site title</title>})
+      expect(output).to match(%r!<title>Site title</title>!)
     end
   end
 
@@ -65,8 +65,8 @@ describe Jekyll::SeoTag do
     let(:page) { make_page('description' => 'foo') }
 
     it 'uses the page description' do
-      expect(output).to match(%r{<meta name="description" content="foo" />})
-      expect(output).to match(%r{<meta property="og:description" content="foo" />})
+      expect(output).to match(%r!<meta name="description" content="foo" />!)
+      expect(output).to match(%r!<meta property="og:description" content="foo" />!)
     end
   end
 
@@ -74,8 +74,8 @@ describe Jekyll::SeoTag do
     let(:page) { make_page('excerpt' => 'foo') }
 
     it 'uses the page excerpt when no page description exists' do
-      expect(output).to match(%r{<meta name="description" content="foo" />})
-      expect(output).to match(%r{<meta property="og:description" content="foo" />})
+      expect(output).to match(%r!<meta name="description" content="foo" />!)
+      expect(output).to match(%r!<meta property="og:description" content="foo" />!)
     end
   end
 
@@ -83,8 +83,8 @@ describe Jekyll::SeoTag do
     let(:site) { make_site('description' => 'foo') }
 
     it 'uses the site description when no page description nor excerpt exist' do
-      expect(output).to match(%r{<meta name="description" content="foo" />})
-      expect(output).to match(%r{<meta property="og:description" content="foo" />})
+      expect(output).to match(%r!<meta name="description" content="foo" />!)
+      expect(output).to match(%r!<meta property="og:description" content="foo" />!)
     end
   end
 
@@ -92,9 +92,9 @@ describe Jekyll::SeoTag do
     let(:site) { make_site('url' => 'http://example.invalid') }
 
     it 'uses the site url to build the seo url' do
-      expected = %r{<link rel="canonical" href="http://example.invalid/page.html" />}
+      expected = %r!<link rel="canonical" href="http://example.invalid/page.html" />!
       expect(output).to match(expected)
-      expected = %r{<meta property="og:url" content="http://example.invalid/page.html" />}
+      expected = %r!<meta property="og:url" content="http://example.invalid/page.html" />!
       expect(output).to match(expected)
     end
 
@@ -102,10 +102,10 @@ describe Jekyll::SeoTag do
       let(:page) { make_page('permalink' => '/page/index.html') }
 
       it "uses replaces '/index.html' with '/'" do
-        expected = %r{<link rel="canonical" href="http://example.invalid/page/" />}
+        expected = %r!<link rel="canonical" href="http://example.invalid/page/" />!
         expect(output).to match(expected)
 
-        expected = %r{<meta property="og:url" content="http://example.invalid/page/" />}
+        expected = %r!<meta property="og:url" content="http://example.invalid/page/" />!
         expect(output).to match(expected)
       end
     end
@@ -114,9 +114,9 @@ describe Jekyll::SeoTag do
       let(:site) { make_site('url' => 'http://example.invalid', 'baseurl' => '/foo') }
 
       it 'uses baseurl to build the seo url' do
-        expected = %r{<link rel="canonical" href="http://example.invalid/foo/page.html" />}
+        expected = %r!<link rel="canonical" href="http://example.invalid/foo/page.html" />!
         expect(output).to match(expected)
-        expected = %r{<meta property="og:url" content="http://example.invalid/foo/page.html" />}
+        expected = %r!<meta property="og:url" content="http://example.invalid/foo/page.html" />!
         expect(output).to match(expected)
       end
     end
@@ -144,7 +144,7 @@ describe Jekyll::SeoTag do
         let(:page) { make_page('image' => { 'path' => '/img/foo.png' }) }
 
         it 'outputs the image' do
-          expected = %r{<meta property="og:image" content="http://example.invalid/img/foo.png" />}
+          expected = %r!<meta property="og:image" content="http://example.invalid/img/foo.png" />!
           expect(output).to match(expected)
         end
       end
@@ -153,7 +153,7 @@ describe Jekyll::SeoTag do
         let(:page) { make_page('image' => { 'facebook' => '/img/facebook.png' }) }
 
         it 'outputs the image' do
-          expected = %r{<meta property="og:image" content="http://example.invalid/img/facebook.png" />}
+          expected = %r!<meta property="og:image" content="http://example.invalid/img/facebook.png" />!
           expect(output).to match(expected)
         end
       end
@@ -162,7 +162,7 @@ describe Jekyll::SeoTag do
         let(:page) { make_page('image' => { 'twitter' => '/img/twitter.png' }) }
 
         it 'outputs the image' do
-          expected = %r{<meta name="twitter:image" content="http://example.invalid/img/twitter.png" />}
+          expected = %r!<meta name="twitter:image" content="http://example.invalid/img/twitter.png" />!
           expect(output).to match(expected)
         end
       end
@@ -172,9 +172,9 @@ describe Jekyll::SeoTag do
         let(:page) { make_page('image' => image) }
 
         it 'outputs the image' do
-          expected = %r{<meta property="og:image:height" content="1" />}
+          expected = %r!<meta property="og:image:height" content="1" />!
           expect(output).to match(expected)
-          expected = %r{<meta property="og:image:width" content="2" />}
+          expected = %r!<meta property="og:image:width" content="2" />!
           expect(output).to match(expected)
         end
       end
@@ -200,7 +200,7 @@ describe Jekyll::SeoTag do
       let(:site) { make_site('title' => 'Foo', 'url' => 'http://example.invalid') }
 
       it 'outputs the site title meta' do
-        expect(output).to match(%r{<meta property="og:site_name" content="Foo" />})
+        expect(output).to match(%r!<meta property="og:site_name" content="Foo" />!)
       end
 
       it 'minifies the output' do
@@ -223,9 +223,9 @@ EOS
     let(:site) { make_site('github' => github_namespace) }
 
     it 'uses site.github.url to build the seo url' do
-      expected = %r{<link rel="canonical" href="http://example.invalid/page.html" \/>}
+      expected = %r!<link rel="canonical" href="http://example.invalid/page.html" \/>!
       expect(output).to match(expected)
-      expected = %r{<meta property="og:url" content="http://example.invalid/page.html" />}
+      expected = %r!<meta property="og:url" content="http://example.invalid/page.html" />!
       expect(output).to match(expected)
     end
   end
@@ -243,7 +243,7 @@ EOS
       let(:page) { make_post(meta) }
 
       it 'outputs post meta' do
-        expected = %r{<meta property="og:type" content="article" />}
+        expected = %r!<meta property="og:type" content="article" />!
         expect(output).to match(expected)
 
         expect(json_data['headline']).to eql('post')
@@ -275,17 +275,17 @@ EOS
     let(:site) { make_site('facebook' => site_facebook) }
 
     it 'outputs facebook admins meta' do
-      expected = %r{<meta property="fb:admins" content="jekyllrb-fb-admins" />}
+      expected = %r!<meta property="fb:admins" content="jekyllrb-fb-admins" />!
       expect(output).to match(expected)
     end
 
     it 'outputs facebook app ID meta' do
-      expected = %r{<meta property="fb:app_id" content="jekyllrb-fb-app_id" />}
+      expected = %r!<meta property="fb:app_id" content="jekyllrb-fb-app_id" />!
       expect(output).to match(expected)
     end
 
     it 'outputs facebook article publisher meta' do
-      expected = %r{<meta property="article:publisher" content="jekyllrb-fb-publisher" />}
+      expected = %r!<meta property="article:publisher" content="jekyllrb-fb-publisher" />!
       expect(output).to match(expected)
     end
   end
@@ -299,13 +299,13 @@ EOS
         let(:page) { make_page('author' => 'benbalter') }
 
         it 'outputs twitter card meta' do
-          expected = %r{<meta name="twitter:card" content="summary" />}
+          expected = %r!<meta name="twitter:card" content="summary" />!
           expect(output).to match(expected)
 
-          expected = %r{<meta name="twitter:site" content="@jekyllrb" />}
+          expected = %r!<meta name="twitter:site" content="@jekyllrb" />!
           expect(output).to match(expected)
 
-          expected = %r{<meta name="twitter:creator" content="@benbalter" />}
+          expected = %r!<meta name="twitter:creator" content="@benbalter" />!
           expect(output).to match(expected)
         end
 
@@ -313,7 +313,7 @@ EOS
           let(:page) { make_page('author' => '@benbalter') }
 
           it 'outputs the twitter card' do
-            expected = %r{<meta name="twitter:creator" content="@benbalter" />}
+            expected = %r!<meta name="twitter:creator" content="@benbalter" />!
             expect(output).to match(expected)
           end
         end
@@ -326,14 +326,14 @@ EOS
           context 'with the author in site.data.authors' do
             let(:author_data) { { 'benbalter' => { 'twitter' => 'test' } } }
             it 'outputs the twitter card' do
-              expected = %r{<meta name="twitter:creator" content="@test" />}
+              expected = %r!<meta name="twitter:creator" content="@test" />!
               expect(output).to match(expected)
             end
           end
 
           context 'without the author in site.data.authors' do
             it 'outputs the twitter card' do
-              expected = %r{<meta name="twitter:creator" content="@benbalter" />}
+              expected = %r!<meta name="twitter:creator" content="@benbalter" />!
               expect(output).to match(expected)
             end
           end
@@ -344,7 +344,7 @@ EOS
         let(:page) { make_page('image' => '/img/foo.png') }
 
         it 'outputs summary card with large image' do
-          expected = %r{<meta name="twitter:card" content="summary_large_image" />}
+          expected = %r!<meta name="twitter:card" content="summary_large_image" />!
           expect(output).to match(expected)
         end
       end
@@ -353,7 +353,7 @@ EOS
         let(:page) { make_page('author' => { 'twitter' => '@test' }) }
 
         it 'supports author data as a hash' do
-          expected = %r{<meta name="twitter:creator" content="@test" />}
+          expected = %r!<meta name="twitter:creator" content="@test" />!
           expect(output).to match(expected)
         end
       end
@@ -362,7 +362,7 @@ EOS
         let(:page) { make_page('authors' => %w(test foo)) }
 
         it 'supports author data as an array' do
-          expected = %r{<meta name="twitter:creator" content="@test" />}
+          expected = %r!<meta name="twitter:creator" content="@test" />!
           expect(output).to match(expected)
         end
       end
@@ -372,7 +372,7 @@ EOS
         let(:site) { make_site('author' => author, 'twitter' => site_twitter) }
 
         it 'supports author data as an hash' do
-          expected = %r{<meta name="twitter:creator" content="@test" />}
+          expected = %r!<meta name="twitter:creator" content="@test" />!
           expect(output).to match(expected)
         end
       end
@@ -423,7 +423,7 @@ EOS
     let(:site) { make_site('name' => 'Site name') }
 
     it 'uses site.name if site.title is not present' do
-      expected = %r{<meta property="og:site_name" content="Site name" />}
+      expected = %r!<meta property="og:site_name" content="Site name" />!
       expect(output).to match(expected)
     end
 
@@ -431,7 +431,7 @@ EOS
       let(:site)  { make_site('name' => 'Site Name', 'title' => 'Site Title') }
 
       it 'uses site.tile if both site.title and site.name are present' do
-        expected = %r{<meta property="og:site_name" content="Site Title" />}
+        expected = %r!<meta property="og:site_name" content="Site Title" />!
         expect(output).to match(expected)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ end
 
 def make_post(options = {})
   filename = File.expand_path('2015-01-01-post.md', CONFIG_DEFAULTS['source'])
-  config = { site: site, collection: site.collections['posts'] }
+  config = { :site => site, :collection => site.collections['posts'] }
   page = Jekyll::Document.new filename, config
   page.merge_data!(options)
   page
@@ -39,5 +39,5 @@ def make_site(options = {})
 end
 
 def make_context(registers = {}, environments = {})
-  Liquid::Context.new(environments, {}, { site: site, page: page }.merge(registers))
+  Liquid::Context.new(environments, {}, { :site => site, :page => page }.merge(registers))
 end


### PR DESCRIPTION
This PR is the result of adding `inherit_gem:\n jekyll: .rubocop.yml` to `.rubocop.yml` and running `rubocop -a` so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.