### PR TITLE
Removes description from title in template

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -21,9 +21,6 @@
   {% assign seo_title = seo_site_title %}
   {% assign seo_page_title = seo_site_title %}
 
-  {% if site.description %}
-    {% assign seo_title = seo_title | append:" - " | append: site.description %}
-  {% endif %}
 {% endif %}
 
 {% if page.seo and page.seo.name %}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,8 @@ def make_page(options = {})
 end
 
 def make_post(options = {})
-  filename = File.expand_path('2015-01-01-post.md', CONFIG_DEFAULTS['source'])
+  #spec/fixtures/2015-01-01-post.md
+  filename = File.expand_path('2015-01-01-post.md', "#{CONFIG_DEFAULTS['source']}/_posts")
   config = { :site => site, :collection => site.collections['posts'] }
   page = Jekyll::Document.new filename, config
   page.merge_data!(options)


### PR DESCRIPTION
This PR removes code that joined the site description to the title.

This issue is that search engines expect the title meta tag to be in the 50-60 character range  ([https://moz.com/learn/seo/title-tag](https://moz.com/learn/seo/title-tag)) and the description meta tag to be out 155 characters ([https://moz.com/learn/seo/meta-description](https://moz.com/learn/seo/meta-description)).   

If you join them, you end up with a title that's in the 205-215 characters range.

I think the default behavior should be to  keep the description and title separate.  