### PR TITLE
Simplify minify regex

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -4,7 +4,16 @@ module Jekyll
   class SeoTag < Liquid::Tag
     attr_accessor :context
 
-    MINIFY_REGEX = %r!([>,]\n|[%}]})\s+?(<|{[{%]|[ ]+\")!
+    # Matches all whitespace that follows either
+    #   1. A '}', which closes a Liquid tag
+    #   2. A '{', which opens a JSON block
+    #   3. A '>' followed by a newline, which closes an XML tag or
+    #   4. A ',' followed by a newline, which ends a JSON line
+    # We will strip all of this whitespace to minify the template
+    # We will not strip any whitespace if the next character is a '-'
+    #   so that we do not interfere with the HTML comment at the
+    #   very begining
+    MINIFY_REGEX = %r!(?<=[{}]|[>,]\n)\s+(?\!-)!
 
     def initialize(_tag_name, text, _tokens)
       super
@@ -51,7 +60,7 @@ module Jekyll
 
     def template_contents
       @template_contents ||= begin
-        File.read(template_path).gsub(MINIFY_REGEX, '\1\2').chomp
+        File.read(template_path).gsub(MINIFY_REGEX, "")
       end
     end
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -241,10 +241,9 @@ EOS
 
       it "minifies JSON-LD" do
         expected = <<-EOS
-  {
-    "@context": "http://schema.org",
-    "@type": "BlogPosting",
-    "headline": "post",
+{"@context": "http://schema.org",
+"@type": "BlogPosting",
+"headline": "post",
 EOS
         expect(output).to match(expected)
       end


### PR DESCRIPTION
This simplifies the minification regular expression.

I _did_ change one test, as the JSON-LD lines are no longer indented, although each attribute is still on its own line. Of course, if we would like to further minify things we can strip out _all_ the newlines, but that might negatively impact readability of the source and would not really gain anything (especially if we assume pages will be served GZIPed).