### PR TITLE
Wraps logo image json data in a publisher property

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -205,7 +205,13 @@
 {% endif %}
 
 {% if seo_site_logo %}
-    "logo": {{ seo_site_logo | jsonify }},
+    "publisher": {
+        "@type": "Organization",
+        "logo": {
+            "@type": "ImageObject",
+            "url": {{ seo_site_logo | jsonify }}
+        }
+    },
 {% endif %}
 
 {% if seo_links %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -184,7 +184,7 @@ describe Jekyll::SeoTag do
       let(:site) { make_site("logo" => "/logo.png", "url" => "http://example.invalid") }
 
       it "outputs the logo" do
-        expect(json_data["logo"]).to eql("http://example.invalid/logo.png")
+        expect(json_data["publisher"]["logo"]["url"]).to eql("http://example.invalid/logo.png")
       end
     end
 
@@ -192,7 +192,7 @@ describe Jekyll::SeoTag do
       let(:site) { make_site("logo" => "http://cdn.example.invalid/logo.png", "url" => "http://example.invalid") }
 
       it "outputs the logo" do
-        expect(json_data["logo"]).to eql("http://cdn.example.invalid/logo.png")
+        expect(json_data["publisher"]["logo"]["url"]).to eql("http://cdn.example.invalid/logo.png")
       end
     end
 


### PR DESCRIPTION
By wrapping the logo image object in a `publisher` property it will pass validation in the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool), and hopefully Google's indexing validation.

Fixes #89