### PR TITLE
Rubocop shouldn't worry if tests are too long

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ Metrics/LineLength:
     - spec/**/*
     - jekyll-seo-tag.gemspec
 
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
Jekyll [does the same thing](https://github.com/jekyll/jekyll/blob/v3.3.1/.rubocop.yml#L21-L24)

/cc #148