### PR TITLE
Add tags to JSON metadata

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -4,6 +4,10 @@
 
   * Rubocop shouldn't worry if tests are too long (#149)
 
+### Minor Enhancements
+
+  * Add support for Bing and Yandex webmaster tools. Closes #147 (#148)
+
 ## 2.1.0
 
 ### Major Enhancement

--- a/README.md
+++ b/README.md
@@ -215,10 +215,9 @@ Or if you have no site specific images simply:
 ```yml
 image:
   path: /img/banner.png
-  height: 100
-  width: 100
 ```
 
+> Using the image dimensions are optional, but the [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/) will consider the JSON-LD to have errors when an image does not have specified dimensions.
 
 ### Setting a default image
 

--- a/README.md
+++ b/README.md
@@ -185,27 +185,25 @@ The following options can be set for any particular page. While the default opti
   * `name` - If the name of the thing that the page represents is different from the page title. (i.e.: "Frank's Café" vs "Welcome to Frank's Café")
   * `type` - The type of things that the page represents. This must be a [Schema.org type](http://schema.org/docs/schemas.html), and will probably usually be something like [`BlogPosting`](http://schema.org/BlogPosting), [`NewsArticle`](http://schema.org/NewsArticle), [`Person`](http://schema.org/Person), [`Organization`](http://schema.org/Organization), etc.
   * `links` - An array of other URLs that represent the same thing that this page represents. For instance, Jane's bio page might include links to Jane's GitHub and Twitter profiles.
-  * `dateModified` - An override for the `dateModified` field in the JSON-LD output. Useful when the file timestamp does not match the true time that the content was modified. 
-  * `author` - The `author` field will match the JSON-LD author output where applicable.
+  * `date_modified` - An override for the `dateModified` field in the JSON-LD output. Useful when the file timestamp does not match the true time that the content was modified.
 
 ### Customizing image output
 
 For most users, setting `image: [path-to-image]` on a per-page basis should be enough. If you need more control over how images are represented, the `image` property can also be an object, with the following options:
 
 * `path` - The relative path to the image. Same as `image: [path-to-image]`
-* `url` - The path to the image to be used in the JSON-LD image object `url`.
 * `twitter` - The relative path to a Twitter-specific image.
 * `facebook` - The relative path to a Facebook-specific image.
 * `height` - The height of the Facebook (`og:image`) image and JSON-LD image object.
 * `width` - The width of the Facebook (`og:image`) image and JSON-LD image object.
 
-The JSON-LD will default to the `image: ` tag unless `url: ` `height: ` and `width: `.
+The JSON-LD will default to the `image: ` tag unless `path: ` `height: ` and `width: `.
 
 You can use any of the above, optional properties, like so:
 
 ```yml
 image:
-  url: /img/banner.png
+  path: /img/banner.png
   twitter: /img/twitter.png
   facebook: /img/facebook.png
   height: 100
@@ -216,7 +214,7 @@ Or if you have no site specific images simply:
 
 ```yml
 image:
-  url: /img/banner.png
+  path: /img/banner.png
   height: 100
   width: 100
 ```

--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ image:
 
 Using the image dimensions are optional, but the [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/) will consider the JSON-LD to have errors with certain types (i.e. BlogPosting) when an image does not have specified dimensions.
 
+#### Deprecated image output
+
+The older method for setting facebook image dimensions (shown below) is **no longer recommended**. It will continue work as intended, but is no longer the suggested procedure due to the lack of clarity in where these dimensions are assigned. 
+
+```yml
+image:
+  facebook: /img/bad_facebook_example.png		
+  height: 100		
+  width: 100		
+```
+
 ### Setting a default image
 
 You can define a default image using [Front Matter default](https://jekyllrb.com/docs/configuration/#front-matter-defaults), to provide a default Twitter Card or OGP image to all of your posts and pages.

--- a/README.md
+++ b/README.md
@@ -198,8 +198,6 @@ For most users, setting `image: [path-to-image]` on a per-page basis should be e
 * `height` - The height of the image in pixels.
 * `width` - The width of image in pixels.
 
-The JSON-LD will default to the `image: ` tag unless `path: ` `height: ` and `width: `.
-
 You can use any of the above, optional properties, like so:
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ The SEO tag will respect any of the following if included in your site's `_confi
 * `social` - For [specifying social profiles](https://developers.google.com/structured-data/customize/social-profiles). The following properties are available:
   * `name` - If the user or organization name differs from the site's name
   * `links` - An array of links to social media profiles.
-  * `date_modified` - (YYYY-MM-DD hh:mm) A manual override for the `dateModified` field in the JSON-LD output. This field will take **first priority** for the `dateModified` output. This is useful when the file timestamp does not match the true time that the content was modified.
-  * A user may also install [Last Modified At](https://github.com/gjtorikian/jekyll-last-modified-at) which will offer an alternative way of providing for the `dateModified` field.
+  * `date_modified` - Manually specify the `dateModified` field in the JSON-LD output to override Jekyll's own `dateModified`. This field will take **first priority** for the `dateModified` JSON-LD output. This is useful when the file timestamp does not match the true time that the content was modified. A user may also install [Last Modified At](https://github.com/gjtorikian/jekyll-last-modified-at) which will offer an alternative way of providing for the `dateModified` field.
 
   ```yml
   social:

--- a/README.md
+++ b/README.md
@@ -185,26 +185,42 @@ The following options can be set for any particular page. While the default opti
   * `name` - If the name of the thing that the page represents is different from the page title. (i.e.: "Frank's Café" vs "Welcome to Frank's Café")
   * `type` - The type of things that the page represents. This must be a [Schema.org type](http://schema.org/docs/schemas.html), and will probably usually be something like [`BlogPosting`](http://schema.org/BlogPosting), [`NewsArticle`](http://schema.org/NewsArticle), [`Person`](http://schema.org/Person), [`Organization`](http://schema.org/Organization), etc.
   * `links` - An array of other URLs that represent the same thing that this page represents. For instance, Jane's bio page might include links to Jane's GitHub and Twitter profiles.
+  * `dateModified` - An override for the `dateModified` field in the JSON-LD output. Useful when the file timestamp does not match the true time that the content was modified. 
+  * `author` - The `author` field will match the JSON-LD author output where applicable.
 
 ### Customizing image output
 
 For most users, setting `image: [path-to-image]` on a per-page basis should be enough. If you need more control over how images are represented, the `image` property can also be an object, with the following options:
 
 * `path` - The relative path to the image. Same as `image: [path-to-image]`
+* `url` - The path to the image to be used in the JSON-LD image object `url`.
 * `twitter` - The relative path to a Twitter-specific image.
 * `facebook` - The relative path to a Facebook-specific image.
-* `height` - The height of the Facebook (`og:image`) image
-* `width` - The width of the Facebook (`og:image`) image
+* `height` - The height of the Facebook (`og:image`) image and JSON-LD image object.
+* `width` - The width of the Facebook (`og:image`) image and JSON-LD image object.
+
+The JSON-LD will default to the `image: ` tag unless `url: ` `height: ` and `width: `.
 
 You can use any of the above, optional properties, like so:
 
 ```yml
 image:
+  url: /img/banner.png
   twitter: /img/twitter.png
   facebook: /img/facebook.png
   height: 100
   width: 100
 ```
+
+Or if you have no site specific images simply:
+
+```yml
+image:
+  url: /img/banner.png
+  height: 100
+  width: 100
+```
+
 
 ### Setting a default image
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ The following options can be set for any particular page. While the default opti
   * `name` - If the name of the thing that the page represents is different from the page title. (i.e.: "Frank's Café" vs "Welcome to Frank's Café")
   * `type` - The type of things that the page represents. This must be a [Schema.org type](http://schema.org/docs/schemas.html), and will probably usually be something like [`BlogPosting`](http://schema.org/BlogPosting), [`NewsArticle`](http://schema.org/NewsArticle), [`Person`](http://schema.org/Person), [`Organization`](http://schema.org/Organization), etc.
   * `links` - An array of other URLs that represent the same thing that this page represents. For instance, Jane's bio page might include links to Jane's GitHub and Twitter profiles.
-  * `date_modified` - An override for the `dateModified` field in the JSON-LD output. Useful when the file timestamp does not match the true time that the content was modified.
+  * `date_modified` - (YYYY-MM-DD hh:mm) A manual override for the `dateModified` field in the JSON-LD output. This field will take **first priority** for the `dateModified` output. This is useful when the file timestamp does not match the true time that the content was modified.
+    * A user may also install [Last Modified At](https://github.com/gjtorikian/jekyll-last-modified-at) which will offer an alternative way of providing for the `dateModified` field.
 
 ### Customizing image output
 
@@ -194,30 +195,33 @@ For most users, setting `image: [path-to-image]` on a per-page basis should be e
 * `path` - The relative path to the image. Same as `image: [path-to-image]`
 * `twitter` - The relative path to a Twitter-specific image.
 * `facebook` - The relative path to a Facebook-specific image.
-* `height` - The height of the Facebook (`og:image`) image and JSON-LD image object.
-* `width` - The width of the Facebook (`og:image`) image and JSON-LD image object.
+* `height` - The height of the image in pixels.
+* `width` - The width of image in pixels.
 
 The JSON-LD will default to the `image: ` tag unless `path: ` `height: ` and `width: `.
 
 You can use any of the above, optional properties, like so:
 
 ```yml
-image:
-  path: /img/banner.png
-  twitter: /img/twitter.png
-  facebook: /img/facebook.png
-  height: 100
-  width: 100
+image: /img/banner.png
 ```
 
-Or if you have no site specific images simply:
+Or if you have Facebook or Twitter specific images simply use:
 
 ```yml
 image:
-  path: /img/banner.png
+  default:
+    path: /img/banner.png
+    height: 100
+    width: 100
+  facebook:
+    path: /img/facebook.png
+    height: 90
+    width: 90
+  twitter: /img/twitter.png
 ```
 
-> Using the image dimensions are optional, but the [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/) will consider the JSON-LD to have errors when an image does not have specified dimensions.
+Using the image dimensions are optional, but the [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/) will consider the JSON-LD to have errors with certain types (i.e. BlogPosting) when an image does not have specified dimensions.
 
 ### Setting a default image
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The SEO tag will respect any of the following if included in your site's `_confi
 * `social` - For [specifying social profiles](https://developers.google.com/structured-data/customize/social-profiles). The following properties are available:
   * `name` - If the user or organization name differs from the site's name
   * `links` - An array of links to social media profiles.
+  * `date_modified` - (YYYY-MM-DD hh:mm) A manual override for the `dateModified` field in the JSON-LD output. This field will take **first priority** for the `dateModified` output. This is useful when the file timestamp does not match the true time that the content was modified.
+  * A user may also install [Last Modified At](https://github.com/gjtorikian/jekyll-last-modified-at) which will offer an alternative way of providing for the `dateModified` field.
 
   ```yml
   social:
@@ -185,8 +187,6 @@ The following options can be set for any particular page. While the default opti
   * `name` - If the name of the thing that the page represents is different from the page title. (i.e.: "Frank's Café" vs "Welcome to Frank's Café")
   * `type` - The type of things that the page represents. This must be a [Schema.org type](http://schema.org/docs/schemas.html), and will probably usually be something like [`BlogPosting`](http://schema.org/BlogPosting), [`NewsArticle`](http://schema.org/NewsArticle), [`Person`](http://schema.org/Person), [`Organization`](http://schema.org/Organization), etc.
   * `links` - An array of other URLs that represent the same thing that this page represents. For instance, Jane's bio page might include links to Jane's GitHub and Twitter profiles.
-  * `date_modified` - (YYYY-MM-DD hh:mm) A manual override for the `dateModified` field in the JSON-LD output. This field will take **first priority** for the `dateModified` output. This is useful when the file timestamp does not match the true time that the content was modified.
-    * A user may also install [Last Modified At](https://github.com/gjtorikian/jekyll-last-modified-at) which will offer an alternative way of providing for the `dateModified` field.
 
 ### Customizing image output
 
@@ -195,41 +195,17 @@ For most users, setting `image: [path-to-image]` on a per-page basis should be e
 * `path` - The relative path to the image. Same as `image: [path-to-image]`
 * `twitter` - The relative path to a Twitter-specific image.
 * `facebook` - The relative path to a Facebook-specific image.
-* `height` - The height of the image in pixels.
-* `width` - The width of image in pixels.
+* `height` - The height of the Facebook (`og:image`) image
+* `width` - The width of the Facebook (`og:image`) image
 
 You can use any of the above, optional properties, like so:
 
 ```yml
-image: /img/banner.png
-```
-
-Or if you have Facebook or Twitter specific images simply use:
-
-```yml
 image:
-  default:
-    path: /img/banner.png
-    height: 100
-    width: 100
-  facebook:
-    path: /img/facebook.png
-    height: 90
-    width: 90
   twitter: /img/twitter.png
-```
-
-Using the image dimensions are optional, but the [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/) will consider the JSON-LD to have errors with certain types (i.e. BlogPosting) when an image does not have specified dimensions.
-
-#### Deprecated image output
-
-The older method for setting facebook image dimensions (shown below) is **no longer recommended**. It will continue work as intended, but is no longer the suggested procedure due to the lack of clarity in where these dimensions are assigned. 
-
-```yml
-image:
-  facebook: /img/bad_facebook_example.png		
-  height: 100		
-  width: 100		
+  facebook: /img/facebook.png
+  height: 100
+  width: 100
 ```
 
 ### Setting a default image

--- a/lib/template.html
+++ b/lib/template.html
@@ -115,8 +115,8 @@
     {% assign seo_page_image_facebook = seo_page_image_facebook | absolute_url %}
   {% endunless %}
   {% assign seo_page_image_facebook = seo_page_image_facebook | escape %}
-  {% assign seo_page_image_facebook_width = page.image.facebook.width %}
-  {% assign seo_page_image_facebook_height = page.image.facebook.height %}
+  {% assign seo_page_image_facebook_width = page.image.facebook.width | default: page.image.width %}
+  {% assign seo_page_image_facebook_height = page.image.facebook.height | default: page.image.height %}
 
   {% assign seo_page_image_twitter = page.image.twitter.path | default: page.image.twitter %}
   {% unless seo_page_image_twitter contains "://" %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -104,10 +104,6 @@
   <meta property="og:title" content="{{ seo_page_title }}" />
 {% endif %}
 
-{% if seo_author %}
-  <meta name="author" content="{{ seo_author }}" />
-{% endif %}
-
 {% if seo_description %}
   <meta name="description" content="{{ seo_description }}" />
   <meta property="og:description" content="{{ seo_description }}" />

--- a/lib/template.html
+++ b/lib/template.html
@@ -62,8 +62,8 @@
     {% endif %}
   {% endif %}
   {% assign seo_author_twitter = seo_author_twitter | replace:"@","" %}
-  {% if seo_author.name %}
-    {% assign seo_author_name = seo_author.name %}
+  {% if seo_author %}
+    {% assign seo_author_name = seo_author %}
   {% endif %}
 {% endif %}
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -63,7 +63,7 @@
   {% endif %}
   {% assign seo_author_twitter = seo_author_twitter | replace:"@","" %}
   {% if seo_author %}
-    {% assign seo_author_name = seo_author %}
+    {% assign seo_author_name = seo_author.name | default: seo_author %}
   {% endif %}
 {% endif %}
 
@@ -210,7 +210,10 @@
 {% endif %}
 
 {% if seo_author_name %}
-    "author": {{ seo_author_name | jsonify }},
+    "author": {
+      "@type": "Person",
+      "name": {{ seo_author_name | jsonify }}
+    },
 {% endif %}
 
 {% if seo_page_image %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -62,9 +62,6 @@
     {% endif %}
   {% endif %}
   {% assign seo_author_twitter = seo_author_twitter | replace:"@","" %}
-  {% if seo_author %}
-    {% assign seo_author_name = seo_author.name | default: seo_author %}
-  {% endif %}
 {% endif %}
 
 {% if page.seo and page.seo.type %}
@@ -105,6 +102,10 @@
 
 {% if seo_page_title %}
   <meta property="og:title" content="{{ seo_page_title }}" />
+{% endif %}
+
+{% if seo_author %}
+  <meta name="author" content="{{ seo_author }}" />
 {% endif %}
 
 {% if seo_description %}
@@ -209,10 +210,10 @@
     "headline": {{ seo_page_title | jsonify }},
 {% endif %}
 
-{% if seo_author_name %}
+{% if seo_author %}
     "author": {
       "@type": "Person",
-      "name": {{ seo_author_name | jsonify }}
+      "name": {{ seo_author | jsonify }}
     },
 {% endif %}
 
@@ -246,8 +247,8 @@
 {% if seo_site_logo %}
     "publisher": {
         "@type": "Organization",
-        {% if seo_author_name %}
-            "name": {{ seo_author_name | jsonify }},
+        {% if seo_author %}
+            "name": {{ seo_author | jsonify }},
         {% endif %}
         "logo": {
             "@type": "ImageObject",

--- a/lib/template.html
+++ b/lib/template.html
@@ -92,7 +92,7 @@
 {% endif %}
 
 {% if page.image %}
-  {% assign seo_page_image = page.image.path | default: page.image.facebook | default: page.image %}
+  {% assign seo_page_image = page.image.path | default: page.image.url | default: page.image.facebook | default: page.image %}
   {% unless seo_page_image contains "://" %}
     {% assign seo_page_image = seo_page_image | absolute_url %}
   {% endunless %}
@@ -214,11 +214,26 @@
 {% endif %}
 
 {% if seo_page_image %}
-    "image": {{ seo_page_image | jsonify }},
+    {% if page.image.height && page.image.width %}
+      "image": {
+          "@type": "ImageObject",
+          "url": {{ seo_page_image | jsonify }},
+          "height": {{ page.image.height | jsonify }},
+          "width": {{ page.image.width | jsonify }}
+      },
+    {% else %}
+        "image": {{ seo_page_image | jsonify }},
+    {% endif %}
 {% endif %}
 
 {% if page.date %}
     "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
+{% endif %}
+
+{% if page.dateModified %}
+    "dateModified": {{ page.dateModified | date_to_xmlschema | jsonify }},
+{% elseif page.date %}
+    "dateModified": {{ page.date | date_to_xmlschema | jsonify }},
 {% endif %}
 
 {% if seo_description %}
@@ -235,6 +250,13 @@
             "@type": "ImageObject",
             "url": {{ seo_site_logo | jsonify }}
         }
+    },
+{% endif %}
+
+{% if seo_type == "BlogPosting" %}
+    "mainEntityOfPage": {
+         "@type": "WebPage",
+         "@id": {{ page.url | replace:'/index.html','/' | absolute_url | jsonify }}
     },
 {% endif %}
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -102,7 +102,7 @@
 {% endif %}
 
 {% if page.image %}
-  {% assign seo_page_image_default = page.image.default.path | default: page.image.default | default: page.image %}
+  {% assign seo_page_image_default = page.image.default.path | default: page.image.default | default: page.image.path | default: page.image %}
   {% unless seo_page_image_default contains "://" %}
     {% assign seo_page_image_default = seo_page_image_default | absolute_url %}
   {% endunless %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -73,6 +73,10 @@
   {% assign seo_author_twitter = seo_author_twitter | replace:"@","" %}
 {% endif %}
 
+{% if page.date_modified or page.last_modified_at or page.date %}
+  {% assign seo_date_modified = page.seo.date_modified | default: page.last_modified_at | default: page.date %}
+{% endif %}
+
 {% if page.seo and page.seo.type %}
     {% assign seo_type = page.seo.type %}
 {% elsif seo_homepage_or_about %}
@@ -98,11 +102,27 @@
 {% endif %}
 
 {% if page.image %}
-  {% assign seo_page_image = page.image.path | default: page.image.facebook | default: page.image %}
-  {% unless seo_page_image contains "://" %}
-    {% assign seo_page_image = seo_page_image | absolute_url %}
+  {% assign seo_page_image_default = page.image.default.path | default: page.image.default | default: page.image %}
+  {% unless seo_page_image_default contains "://" %}
+    {% assign seo_page_image_default = seo_page_image_default | absolute_url %}
   {% endunless %}
-  {% assign seo_page_image = seo_page_image | escape %}
+  {% assign seo_page_image_default = seo_page_image_default | escape %}
+  {% assign seo_page_image_default_width = page.image.default.width %}
+  {% assign seo_page_image_default_height = page.image.default.height %}
+
+  {% assign seo_page_image_facebook = page.image.facebook.path | default: page.image.facebook %}
+  {% unless seo_page_image_facebook contains "://" %}
+    {% assign seo_page_image_facebook = seo_page_image_facebook | absolute_url %}
+  {% endunless %}
+  {% assign seo_page_image_facebook = seo_page_image_facebook | escape %}
+  {% assign seo_page_image_facebook_width = page.image.facebook.width %}
+  {% assign seo_page_image_facebook_height = page.image.facebook.height %}
+
+  {% assign seo_page_image_twitter = page.image.twitter.path | default: page.image.twitter %}
+  {% unless seo_page_image_twitter contains "://" %}
+    {% assign seo_page_image_twitter = seo_page_image_twitter | absolute_url %}
+  {% endunless %}
+  {% assign seo_page_image_twitter = seo_page_image_twitter | escape %}
 {% endif %}
 
 {% if seo_tag.title and seo_title %}
@@ -131,18 +151,27 @@
   <meta property="og:site_name" content="{{ seo_site_title }}" />
 {% endif %}
 
-{% if seo_page_image %}
-<meta property="og:image" content="{{ seo_page_image }}" />
-  {% if page.image.height %}
-    <meta property="og:image:height" content="{{ page.image.height }}" />
+{% if page.image %}
+  {% if page.image.facebook %}
+    {% assign local_seo_page_image = seo_page_image_facebook %}
+    {% assign local_seo_page_image_height = seo_page_image_facebook_height %}
+    {% assign local_seo_page_image_width = seo_page_image_facebook_width %}
+  {% else %}
+    {% assign local_seo_page_image = seo_page_image_default %}
+    {% assign local_seo_page_image_height = seo_page_image_default_height %}
+    {% assign local_seo_page_image_width = seo_page_image_default_width %}
   {% endif %}
-  {% if page.image.width %}
-    <meta property="og:image:width" content="{{ page.image.width }}" />
+  <meta property="og:image" content="{{ local_seo_page_image }}" />
+  {% if local_seo_page_image_height %}
+    <meta property="og:image:height" content="{{ local_seo_page_image_height }}" />
+  {% endif %}
+  {% if local_seo_page_image_width %}
+    <meta property="og:image:width" content="{{ local_seo_page_image_width }}" />
   {% endif %}
 {% endif %}
 
 {% if page.image.twitter %}
-  <meta name="twitter:image" content="{{ page.image.twitter | absolute_url }}" />
+  <meta name="twitter:image" content="{{ seo_page_image_twitter }}" />
 {% endif %}
 
 {% if page.date %}
@@ -158,7 +187,7 @@
 {% endif %}
 
 {% if site.twitter %}
-  {% if seo_page_image or page.image.twitter %}
+  {% if page.image or page.image.twitter %}
     <meta name="twitter:card" content="summary_large_image" />
   {% else %}
     <meta name="twitter:card" content="summary" />
@@ -226,16 +255,16 @@
     },
 {% endif %}
 
-{% if seo_page_image %}
-    {% if page.image.height && page.image.width %}
+{% if seo_page_image_default %}
+    {% if seo_page_image_default_height && seo_page_image_default_width %}
       "image": {
           "@type": "ImageObject",
-          "url": {{ seo_page_image | jsonify }},
-          "height": {{ page.image.height | jsonify }},
-          "width": {{ page.image.width | jsonify }}
+          "url": {{ seo_page_image_default | jsonify }},
+          "height": {{ seo_page_image_default_height | jsonify }},
+          "width": {{ seo_page_image_default_width | jsonify }}
       },
     {% else %}
-        "image": {{ seo_page_image | jsonify }},
+        "image": {{ seo_page_image_default | jsonify }},
     {% endif %}
 {% endif %}
 
@@ -243,10 +272,8 @@
     "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
 {% endif %}
 
-{% if page.date_modified %}
-    "dateModified": {{ page.date_modified | date_to_xmlschema | jsonify }},
-{% elsif page.date %}
-    "dateModified": {{ page.date | date_to_xmlschema | jsonify }},
+{% if seo_date_modified %}
+    "dateModified": {{ seo_date_modified | date_to_xmlschema | jsonify }},
 {% endif %}
 
 {% if seo_description %}
@@ -266,7 +293,7 @@
     },
 {% endif %}
 
-{% if seo_type == "BlogPosting" or seo_type == "CreativeWork" %}
+{% if seo_type == "BlogPosting" or seo_type == "CreativeWork"%}
     "mainEntityOfPage": {
          "@type": "WebPage",
          "@id": {{ page.url | replace:'/index.html','/' | absolute_url | jsonify }}

--- a/lib/template.html
+++ b/lib/template.html
@@ -66,7 +66,7 @@
 {% endif %}
 
 {% if page.date_modified or page.last_modified_at or page.date %}
-  {% assign seo_date_modified = page.seo.date_modified | default: page.last_modified_at | default: page.date %}
+  {% assign seo_date_modified = page.seo.date_modified | default: page.last_modified_at %}
 {% endif %}
 
 {% if page.seo and page.seo.type %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -266,7 +266,7 @@
     },
 {% endif %}
 
-{% if seo_type == "BlogPosting" %}
+{% if seo_type == "BlogPosting" or seo_type == "CreativeWork" %}
     "mainEntityOfPage": {
          "@type": "WebPage",
          "@id": {{ page.url | replace:'/index.html','/' | absolute_url | jsonify }}

--- a/lib/template.html
+++ b/lib/template.html
@@ -64,7 +64,7 @@
   {% assign seo_author_twitter = seo_author_twitter | replace:"@","" %}
   {% if seo_author.name %}
     {% assign seo_author_name = seo_author.name %}
-  {% else %}
+  {% endif %}
 {% endif %}
 
 {% if page.seo and page.seo.type %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -94,27 +94,11 @@
 {% endif %}
 
 {% if page.image %}
-  {% assign seo_page_image_default = page.image.default.path | default: page.image.default | default: page.image.path | default: page.image %}
-  {% unless seo_page_image_default contains "://" %}
-    {% assign seo_page_image_default = seo_page_image_default | absolute_url %}
+  {% assign seo_page_image = page.image.path | default: page.image.facebook | default: page.image %}
+  {% unless seo_page_image contains "://" %}
+    {% assign seo_page_image = seo_page_image | absolute_url %}
   {% endunless %}
-  {% assign seo_page_image_default = seo_page_image_default | escape %}
-  {% assign seo_page_image_default_width = page.image.default.width %}
-  {% assign seo_page_image_default_height = page.image.default.height %}
-
-  {% assign seo_page_image_facebook = page.image.facebook.path | default: page.image.facebook %}
-  {% unless seo_page_image_facebook contains "://" %}
-    {% assign seo_page_image_facebook = seo_page_image_facebook | absolute_url %}
-  {% endunless %}
-  {% assign seo_page_image_facebook = seo_page_image_facebook | escape %}
-  {% assign seo_page_image_facebook_width = page.image.facebook.width | default: page.image.width %}
-  {% assign seo_page_image_facebook_height = page.image.facebook.height | default: page.image.height %}
-
-  {% assign seo_page_image_twitter = page.image.twitter.path | default: page.image.twitter %}
-  {% unless seo_page_image_twitter contains "://" %}
-    {% assign seo_page_image_twitter = seo_page_image_twitter | absolute_url %}
-  {% endunless %}
-  {% assign seo_page_image_twitter = seo_page_image_twitter | escape %}
+  {% assign seo_page_image = seo_page_image | escape %}
 {% endif %}
 
 {% if seo_tag.title and seo_title %}
@@ -143,27 +127,18 @@
   <meta property="og:site_name" content="{{ seo_site_title }}" />
 {% endif %}
 
-{% if page.image %}
-  {% if page.image.facebook %}
-    {% assign local_seo_page_image = seo_page_image_facebook %}
-    {% assign local_seo_page_image_height = seo_page_image_facebook_height %}
-    {% assign local_seo_page_image_width = seo_page_image_facebook_width %}
-  {% else %}
-    {% assign local_seo_page_image = seo_page_image_default %}
-    {% assign local_seo_page_image_height = seo_page_image_default_height %}
-    {% assign local_seo_page_image_width = seo_page_image_default_width %}
+{% if seo_page_image %}
+<meta property="og:image" content="{{ seo_page_image }}" />
+  {% if page.image.height %}
+    <meta property="og:image:height" content="{{ page.image.height }}" />
   {% endif %}
-  <meta property="og:image" content="{{ local_seo_page_image }}" />
-  {% if local_seo_page_image_height %}
-    <meta property="og:image:height" content="{{ local_seo_page_image_height }}" />
-  {% endif %}
-  {% if local_seo_page_image_width %}
-    <meta property="og:image:width" content="{{ local_seo_page_image_width }}" />
+  {% if page.image.width %}
+    <meta property="og:image:width" content="{{ page.image.width }}" />
   {% endif %}
 {% endif %}
 
 {% if page.image.twitter %}
-  <meta name="twitter:image" content="{{ seo_page_image_twitter }}" />
+  <meta name="twitter:image" content="{{ page.image.twitter | absolute_url }}" />
 {% endif %}
 
 {% if page.date %}
@@ -179,7 +154,7 @@
 {% endif %}
 
 {% if site.twitter %}
-  {% if page.image or page.image.twitter %}
+  {% if seo_page_image or page.image.twitter %}
     <meta name="twitter:card" content="summary_large_image" />
   {% else %}
     <meta name="twitter:card" content="summary" />
@@ -242,22 +217,13 @@
 
 {% if seo_author %}
     "author": {
-      "@type": "Person",
-      "name": {{ seo_author | jsonify }}
+       "@type": "Person",
+       "name": {{ seo_author | jsonify }}
     },
 {% endif %}
 
-{% if seo_page_image_default %}
-    {% if seo_page_image_default_height && seo_page_image_default_width %}
-      "image": {
-          "@type": "ImageObject",
-          "url": {{ seo_page_image_default | jsonify }},
-          "height": {{ seo_page_image_default_height | jsonify }},
-          "width": {{ seo_page_image_default_width | jsonify }}
-      },
-    {% else %}
-        "image": {{ seo_page_image_default | jsonify }},
-    {% endif %}
+{% if seo_page_image %}
+    "image": {{ seo_page_image | jsonify }},
 {% endif %}
 
 {% if page.date %}
@@ -287,8 +253,8 @@
 
 {% if seo_type == "BlogPosting" or seo_type == "CreativeWork"%}
     "mainEntityOfPage": {
-         "@type": "WebPage",
-         "@id": {{ page.url | replace:'/index.html','/' | absolute_url | jsonify }}
+        "@type": "WebPage",
+        "@id": {{ page.url | replace:'/index.html','/' | absolute_url | jsonify }}
     },
 {% endif %}
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -62,6 +62,9 @@
     {% endif %}
   {% endif %}
   {% assign seo_author_twitter = seo_author_twitter | replace:"@","" %}
+  {% if seo_author.name %}
+    {% assign seo_author_name = seo_author.name %}
+  {% else %}
 {% endif %}
 
 {% if page.seo and page.seo.type %}
@@ -206,6 +209,10 @@
     "headline": {{ seo_page_title | jsonify }},
 {% endif %}
 
+{% if seo_author_name %}
+    "author": {{ seo_author_name | jsonify }},
+{% endif %}
+
 {% if seo_page_image %}
     "image": {{ seo_page_image | jsonify }},
 {% endif %}
@@ -221,6 +228,9 @@
 {% if seo_site_logo %}
     "publisher": {
         "@type": "Organization",
+        {% if seo_author_name %}
+            "Name": {{ seo_author_name | jsonify }},
+        {% endif %}
         "logo": {
             "@type": "ImageObject",
             "url": {{ seo_site_logo | jsonify }}

--- a/lib/template.html
+++ b/lib/template.html
@@ -229,7 +229,7 @@
     "publisher": {
         "@type": "Organization",
         {% if seo_author_name %}
-            "Name": {{ seo_author_name | jsonify }},
+            "name": {{ seo_author_name | jsonify }},
         {% endif %}
         "logo": {
             "@type": "ImageObject",

--- a/lib/template.html
+++ b/lib/template.html
@@ -232,7 +232,7 @@
 
 {% if page.dateModified %}
     "dateModified": {{ page.dateModified | date_to_xmlschema | jsonify }},
-{% elseif page.date %}
+{% elsif page.date %}
     "dateModified": {{ page.date | date_to_xmlschema | jsonify }},
 {% endif %}
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -89,7 +89,7 @@
 {% endif %}
 
 {% if page.image %}
-  {% assign seo_page_image = page.image.path | default: page.image.url | default: page.image.facebook | default: page.image %}
+  {% assign seo_page_image = page.image.path | default: page.image.facebook | default: page.image %}
   {% unless seo_page_image contains "://" %}
     {% assign seo_page_image = seo_page_image | absolute_url %}
   {% endunless %}
@@ -230,8 +230,8 @@
     "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
 {% endif %}
 
-{% if page.dateModified %}
-    "dateModified": {{ page.dateModified | date_to_xmlschema | jsonify }},
+{% if page.date_modified %}
+    "dateModified": {{ page.date_modified | date_to_xmlschema | jsonify }},
 {% elsif page.date %}
     "dateModified": {{ page.date | date_to_xmlschema | jsonify }},
 {% endif %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -188,53 +188,12 @@ describe Jekyll::SeoTag do
     end
 
     context "with page.image as an object" do
-      context "when given 'image' with a path" do
+      context "when given a path" do
         let(:page) { make_page("image" => { "path" => "/img/foo.png" }) }
 
         it "outputs the image" do
           expected = %r!<meta property="og:image" content="http://example.invalid/img/foo.png" />!
           expect(output).to match(expected)
-        end
-      end
-
-      context "when given a default image" do
-        let(:page) { make_page("image" => { "default" => "/img/default.png" }) }
-
-        it "outputs the image" do
-          expected = %r!<meta property="og:image" content="http://example.invalid/img/default.png" />!
-          expect(output).to match(expected)
-        end
-
-        it "outputs the default image JSON item" do
-          expect(json_data["image"]).to eql("http://example.invalid/img/default.png")
-        end
-      end
-
-      context "when given a default image as a path" do
-        let(:page) { make_page("image" => { "default" => { "path" => "/img/default.png" } }) }
-
-        it "outputs the image" do
-          expected = %r!<meta property="og:image" content="http://example.invalid/img/default.png" />!
-          expect(output).to match(expected)
-        end
-
-        it "outputs the default image JSON item" do
-          expect(json_data["image"]).to eql("http://example.invalid/img/default.png")
-        end
-      end
-
-      context "when given a default image with dimensions" do
-        let(:page) { make_page("image" => { "default" => { "path" => "/img/default.png", "height" => 1, "width" => 2 } }) }
-
-        it "outputs the image" do
-          expected = %r!<meta property="og:image" content="http://example.invalid/img/default.png" />!
-          expect(output).to match(expected)
-        end
-
-        it "outputs the default image JSON object with dimensions" do
-          expect(json_data["image"]["url"]).to eql("http://example.invalid/img/default.png")
-          expect(json_data["image"]["height"]).to eql(1)
-          expect(json_data["image"]["width"]).to eql(2)
         end
       end
 
@@ -247,67 +206,6 @@ describe Jekyll::SeoTag do
         end
       end
 
-      context "when given a facebook image as a path" do
-        let(:page) { make_page("image" => { "facebook" => { "path" => "/img/facebook.png" } }) }
-
-        it "outputs the image" do
-          expected = %r!<meta property="og:image" content="http://example.invalid/img/facebook.png" />!
-          expect(output).to match(expected)
-        end
-      end
-
-      # Ensuring the facebook image takes priority for OG tags, and Default for JSON
-      context "when given a facebook image (with dimensions) and a default image (with different dimensions)" do
-        let(:meta) do
-          {
-            "image" => {
-              "facebook" => { "path" => "/img/facebook.png", "height" => 1, "width" => 2 },
-              "default"  => { "path" => "/img/default.png", "height" => 3, "width" => 4 },
-            },
-          }
-        end
-        let(:page) { make_page(meta) }
-
-        it "outputs the facebook image with its dimensions" do
-          expected = %r!<meta property="og:image:height" content="1" />!
-          expect(output).to match(expected)
-          expected = %r!<meta property="og:image:width" content="2" />!
-          expect(output).to match(expected)
-        end
-
-        it "outputs the default image JSON object with dimensions" do
-          expect(json_data["image"]["url"]).to eql("http://example.invalid/img/default.png")
-          expect(json_data["image"]["height"]).to eql(3)
-          expect(json_data["image"]["width"]).to eql(4)
-        end
-      end
-
-      # Making sure the facebook image does not inherit the default image dimensions
-      context "when given a facebook image without dimensions and a default image with dimensions" do
-        let(:meta) do
-          {
-            "image" => {
-              "facebook" => { "path" => "/img/facebook.png" },
-              "default"  => { "path" => "/img/default.png", "height" => 3, "width" => 4 },
-            },
-          }
-        end
-        let(:page) { make_page(meta) }
-
-        it "outputs the facebook image without dimensions" do
-          expected = %r!<meta property="og:image:height" content="3" />!
-          expect(output).not_to match(expected)
-          expected = %r!<meta property="og:image:width" content="4" />!
-          expect(output).not_to match(expected)
-        end
-
-        it "outputs the default image JSON object with dimensions" do
-          expect(json_data["image"]["url"]).to eql("http://example.invalid/img/default.png")
-          expect(json_data["image"]["height"]).to eql(3)
-          expect(json_data["image"]["width"]).to eql(4)
-        end
-      end
-
       context "when given a twitter image" do
         let(:page) { make_page("image" => { "twitter" => "/img/twitter.png" }) }
 
@@ -317,18 +215,9 @@ describe Jekyll::SeoTag do
         end
       end
 
-      context "when given a twitter image as a path" do
-        let(:page) { make_page("image" => { "twitter" => { "path" => "/img/twitter.png" } }) }
-
-        it "outputs the image" do
-          expected = %r!<meta name="twitter:image" content="http://example.invalid/img/twitter.png" />!
-          expect(output).to match(expected)
-        end
-      end
-
-      # A legacy test for an old implementation of facebook height and width
-      context "when given the image height and width (legacy)" do
-        let(:page) { make_page("image" => { "facebook" => "/img/foo.png", "height" => 1, "width" => 2 }) }
+      context "when given the image height and width" do
+        let(:image) { { "facebook" => "/img/foo.png", "height" => 1, "width" => 2 } }
+        let(:page) { make_page("image" => image) }
 
         it "outputs the image" do
           expected = %r!<meta property="og:image:height" content="1" />!

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -212,6 +212,77 @@ describe Jekyll::SeoTag do
       end
     end
 
+    context "with image.url only" do
+      let(:meta) do
+        {
+          "image" =>  {"url" => "/img/banner.png"},
+          "url" => "http://example.invalid"
+        }
+      end
+      let(:page) { make_post(meta) }
+
+      it "outputs the image object" do
+        expect(json_data["image"]).to eql("http://example.invalid/img/banner.png")
+      end
+    end
+
+    context "with page.author" do
+      let(:site) { make_site("logo" => "/logo.png", "url" => "http://example.invalid") }
+      let(:page) { make_post("author" => "Mr. Foo") }
+
+      it "outputs the author" do
+        expect(json_data["author"]).to eql("Mr. Foo")
+      end
+
+      it "outputs the publisher author" do
+        expect(json_data["publisher"]["name"]).to eql("Mr. Foo")
+      end
+    end
+
+    context "with page.date only" do
+      let(:page) { make_post("date" => "2017-01-01T01:00:00-05:00") }
+
+      it "outputs the datePublished" do
+        expect(json_data["datePublished"]).to eql("2017-01-01T01:00:00-05:00")
+        expect(json_data["dateModified"]).to eql("2017-01-01T01:00:00-05:00")
+      end
+    end
+
+    context "with page.dateModified" do
+      let(:page) { make_post("date" => "2017-01-01T01:00:00-05:00", "dateModified" => "2017-02-02T02:00:00-05:00") }
+
+      it "outputs the datePublished" do
+        expect(json_data["datePublished"]).to eql("2017-01-01T01:00:00-05:00")
+      end
+
+      it "outputs the dateModified" do
+        expect(json_data["dateModified"]).to eql("2017-02-02T02:00:00-05:00")
+      end
+    end
+
+    context "with page.author" do
+      let(:site) { make_site("logo" => "/logo.png", "url" => "http://example.invalid") }
+      let(:page) { make_post("author" => "Mr. Foo") }
+
+      it "outputs the author" do
+        expect(json_data["author"]).to eql("Mr. Foo")
+      end
+
+      it "outputs the publisher author" do
+        expect(json_data["publisher"]["name"]).to eql("Mr. Foo")
+      end
+    end
+
+    context "with seo type is BlogPosting" do
+      let(:site) { make_site("url" => "http://example.invalid") }
+      let(:page) { make_post("seo" => {"type" => "BlogPosting"},"permalink" => "/foo/") }
+
+      it "outputs the mainEntityOfPage" do
+        expect(json_data["mainEntityOfPage"]["@type"]).to eql("WebPage")
+        expect(json_data["mainEntityOfPage"]["@id"]).to eql("http://example.invalid/foo/")
+      end
+    end
+
     context "with site.title" do
       let(:site) { make_site("title" => "Foo", "url" => "http://example.invalid") }
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -177,6 +177,17 @@ describe Jekyll::SeoTag do
           expect(output).to match(expected)
         end
       end
+
+      context "when given the image height and width (legacy)" do
+        let(:page) { make_page("image" => { "facebook" => "/img/foo.png", "height" => 1, "width" => 2 } ) }
+
+        it "outputs the image" do
+          expected = %r!<meta property="og:image:height" content="1" />!
+          expect(output).to match(expected)
+          expected = %r!<meta property="og:image:width" content="2" />!
+          expect(output).to match(expected)
+        end
+      end
     end
 
     context "with site.logo" do

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -70,6 +70,14 @@ describe Jekyll::SeoTag do
     end
   end
 
+  context "with page.author" do
+    let(:page) { make_page("author" => "Mr. Foo") }
+
+    it "uses the page author" do
+      expect(output).to match(%r!<meta name="author" content="Mr. Foo" />!)
+    end
+  end
+
   context "with page.excerpt" do
     let(:page) { make_page("excerpt" => "foo") }
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -70,14 +70,6 @@ describe Jekyll::SeoTag do
     end
   end
 
-  context "with page.author" do
-    let(:page) { make_page("author" => "Mr. Foo") }
-
-    it "uses the page author" do
-      expect(output).to match(%r!<meta name="author" content="Mr. Foo" />!)
-    end
-  end
-
   context "with page.excerpt" do
     let(:page) { make_page("excerpt" => "foo") }
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -196,10 +196,10 @@ describe Jekyll::SeoTag do
       end
     end
 
-    context "with image.url, image.height, and image.width" do
+    context "with image.path, image.height, and image.width" do
       let(:meta) do
         {
-          "image" => { "url" => "/img/banner.png", "height" => 1, "width" => 2 },
+          "image" => { "path" => "/img/banner.png", "height" => 1, "width" => 2 },
           "url"   => "http://example.invalid"
         }
       end
@@ -212,10 +212,10 @@ describe Jekyll::SeoTag do
       end
     end
 
-    context "with image.url only" do
+    context "with image.path only" do
       let(:meta) do
         {
-          "image" => { "url" => "/img/banner.png" },
+          "image" => { "path" => "/img/banner.png" },
           "url"   => "http://example.invalid"
         }
       end

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -196,6 +196,22 @@ describe Jekyll::SeoTag do
       end
     end
 
+    context "with image.url, image.height, and image.width" do
+      let(:meta) do
+        {
+          "image" =>  {"url" => "/img/banner.png","height" => 1,"width" => 2},
+          "url" => "http://example.invalid"
+        }
+      end
+      let(:page) { make_post(meta) }
+
+      it "outputs the image object with dimensions" do
+        expect(json_data["image"]["url"]).to eql("http://example.invalid/img/banner.png")
+        expect(json_data["image"]["height"]).to eql(1)
+        expect(json_data["image"]["width"]).to eql(2)
+      end
+    end
+
     context "with site.title" do
       let(:site) { make_site("title" => "Foo", "url" => "http://example.invalid") }
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -239,27 +239,6 @@ describe Jekyll::SeoTag do
       end
     end
 
-    context "with page.date only" do
-      let(:page) { make_post("date" => "2017-01-01T01:00:00-05:00") }
-
-      it "outputs the datePublished" do
-        expect(json_data["datePublished"]).to eql("2017-01-01T01:00:00-05:00")
-        expect(json_data["dateModified"]).to eql("2017-01-01T01:00:00-05:00")
-      end
-    end
-
-    context "with page.dateModified" do
-      let(:page) { make_post("date" => "2017-01-01T01:00:00-05:00", "dateModified" => "2017-02-02T02:00:00-05:00") }
-
-      it "outputs the datePublished" do
-        expect(json_data["datePublished"]).to eql("2017-01-01T01:00:00-05:00")
-      end
-
-      it "outputs the dateModified" do
-        expect(json_data["dateModified"]).to eql("2017-02-02T02:00:00-05:00")
-      end
-    end
-
     context "with page.author" do
       let(:site) { make_site("logo" => "/logo.png", "url" => "http://example.invalid") }
       let(:page) { make_post("author" => "Mr. Foo") }

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -226,23 +226,9 @@ describe Jekyll::SeoTag do
       end
     end
 
-    context "with page.author.name" do
+    context "with page.author" do
       let(:site) { make_site("logo" => "/logo.png", "url" => "http://example.invalid") }
       let(:page) { make_post("author" => "Mr. Foo") }
-
-      it "outputs the author" do
-        expect(json_data["author"]["@type"]).to eql("Person")
-        expect(json_data["author"]["name"]).to eql("Mr. Foo")
-      end
-
-      it "outputs the publisher author" do
-        expect(json_data["publisher"]["name"]).to eql("Mr. Foo")
-      end
-    end
-
-    context "with only page.author" do
-      let(:site) { make_site("logo" => "/logo.png", "url" => "http://example.invalid") }
-      let(:page) { make_post("author" => { "name" => "Mr. Foo" }) }
 
       it "outputs the author" do
         expect(json_data["author"]["@type"]).to eql("Person")

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -141,7 +141,7 @@ describe Jekyll::SeoTag do
 
     context "with page.image as an object" do
       context "when given a path" do
-        let(:page) { make_page("image" => { "default" => "/img/foo.png" }) }
+        let(:page) { make_page("image" => { "path" => "/img/foo.png" }) }
 
         it "outputs the image" do
           expected = %r!<meta property="og:image" content="http://example.invalid/img/foo.png" />!

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -237,11 +237,15 @@ describe Jekyll::SeoTag do
     end
 
     context "with absolute site.logo" do
-      let(:site) { make_site("logo" => "http://cdn.example.invalid/logo.png", "url" => "http://example.invalid", "author" => "Mr. Foo") }
+      let(:site) { make_site("logo" => "http://cdn.example.invalid/logo.png", "url" => "http://example.invalid") }
 
       it "outputs the logo" do
         expect(json_data["publisher"]["logo"]["url"]).to eql("http://cdn.example.invalid/logo.png")
       end
+    end
+
+    context "with site.logo and page.author" do
+      let(:site) { make_site("logo" => "http://cdn.example.invalid/logo.png", "url" => "http://example.invalid", "author" => "Mr. Foo") }
 
       it "outputs the author" do
         expect(json_data["publisher"]["name"]).to eql("Mr. Foo")

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -200,7 +200,7 @@ describe Jekyll::SeoTag do
       let(:meta) do
         {
           "image" => { "path" => "/img/banner.png", "height" => 1, "width" => 2 },
-          "url"   => "http://example.invalid"
+          "url"   => "http://example.invalid",
         }
       end
       let(:page) { make_post(meta) }
@@ -216,7 +216,7 @@ describe Jekyll::SeoTag do
       let(:meta) do
         {
           "image" => { "path" => "/img/banner.png" },
-          "url"   => "http://example.invalid"
+          "url"   => "http://example.invalid",
         }
       end
       let(:page) { make_post(meta) }

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -199,8 +199,8 @@ describe Jekyll::SeoTag do
     context "with image.url, image.height, and image.width" do
       let(:meta) do
         {
-          "image" =>  {"url" => "/img/banner.png","height" => 1,"width" => 2},
-          "url" => "http://example.invalid"
+          "image" => { "url" => "/img/banner.png", "height" => 1, "width" => 2 },
+          "url"   => "http://example.invalid"
         }
       end
       let(:page) { make_post(meta) }
@@ -215,8 +215,8 @@ describe Jekyll::SeoTag do
     context "with image.url only" do
       let(:meta) do
         {
-          "image" =>  {"url" => "/img/banner.png"},
-          "url" => "http://example.invalid"
+          "image" => { "url" => "/img/banner.png" },
+          "url"   => "http://example.invalid"
         }
       end
       let(:page) { make_post(meta) }
@@ -254,7 +254,7 @@ describe Jekyll::SeoTag do
 
     context "with seo type is BlogPosting" do
       let(:site) { make_site("url" => "http://example.invalid") }
-      let(:page) { make_post("seo" => {"type" => "BlogPosting"},"permalink" => "/foo/") }
+      let(:page) { make_post("seo" => { "type" => "BlogPosting" }, "permalink" => "/foo/") }
 
       it "outputs the mainEntityOfPage" do
         expect(json_data["mainEntityOfPage"]["@type"]).to eql("WebPage")

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -141,7 +141,7 @@ describe Jekyll::SeoTag do
 
     context "with page.image as an object" do
       context "when given a path" do
-        let(:page) { make_page("image" => { "path" => "/img/foo.png" }) }
+        let(:page) { make_page("image" => { "default" => "/img/foo.png" }) }
 
         it "outputs the image" do
           expected = %r!<meta property="og:image" content="http://example.invalid/img/foo.png" />!
@@ -168,8 +168,7 @@ describe Jekyll::SeoTag do
       end
 
       context "when given the image height and width" do
-        let(:image) { { "facebook" => "/img/foo.png", "height" => 1, "width" => 2 } }
-        let(:page) { make_page("image" => image) }
+        let(:page) { make_page("image" => { "facebook" => { "path" => "/img/foo.png", "height" => 1, "width" => 2 } }) }
 
         it "outputs the image" do
           expected = %r!<meta property="og:image:height" content="1" />!
@@ -196,10 +195,10 @@ describe Jekyll::SeoTag do
       end
     end
 
-    context "with image.path, image.height, and image.width" do
+    context "with image.default.path, image.default.height, and image.default.width" do
       let(:meta) do
         {
-          "image" => { "path" => "/img/banner.png", "height" => 1, "width" => 2 },
+          "image" => { "default" => { "path" => "/img/banner.png", "height" => 1, "width" => 2 } },
           "url"   => "http://example.invalid",
         }
       end
@@ -209,20 +208,6 @@ describe Jekyll::SeoTag do
         expect(json_data["image"]["url"]).to eql("http://example.invalid/img/banner.png")
         expect(json_data["image"]["height"]).to eql(1)
         expect(json_data["image"]["width"]).to eql(2)
-      end
-    end
-
-    context "with image.path only" do
-      let(:meta) do
-        {
-          "image" => { "path" => "/img/banner.png" },
-          "url"   => "http://example.invalid",
-        }
-      end
-      let(:page) { make_post(meta) }
-
-      it "outputs the image object" do
-        expect(json_data["image"]).to eql("http://example.invalid/img/banner.png")
       end
     end
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -226,12 +226,13 @@ describe Jekyll::SeoTag do
       end
     end
 
-    context "with page.author" do
+    context "with page.author.name" do
       let(:site) { make_site("logo" => "/logo.png", "url" => "http://example.invalid") }
       let(:page) { make_post("author" => "Mr. Foo") }
 
       it "outputs the author" do
-        expect(json_data["author"]).to eql("Mr. Foo")
+        expect(json_data["author"]["@type"]).to eql("Person")
+        expect(json_data["author"]["name"]).to eql("Mr. Foo")
       end
 
       it "outputs the publisher author" do
@@ -239,12 +240,13 @@ describe Jekyll::SeoTag do
       end
     end
 
-    context "with page.author" do
+    context "with only page.author" do
       let(:site) { make_site("logo" => "/logo.png", "url" => "http://example.invalid") }
-      let(:page) { make_post("author" => "Mr. Foo") }
+      let(:page) { make_post("author" => { "name" => "Mr. Foo" }) }
 
       it "outputs the author" do
-        expect(json_data["author"]).to eql("Mr. Foo")
+        expect(json_data["author"]["@type"]).to eql("Person")
+        expect(json_data["author"]["name"]).to eql("Mr. Foo")
       end
 
       it "outputs the publisher author" do

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -179,7 +179,7 @@ describe Jekyll::SeoTag do
       end
 
       context "when given the image height and width (legacy)" do
-        let(:page) { make_page("image" => { "facebook" => "/img/foo.png", "height" => 1, "width" => 2 } ) }
+        let(:page) { make_page("image" => { "facebook" => "/img/foo.png", "height" => 1, "width" => 2 }) }
 
         it "outputs the image" do
           expected = %r!<meta property="og:image:height" content="1" />!

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -250,6 +250,16 @@ describe Jekyll::SeoTag do
       end
     end
 
+    context "with seo type is CreativeWork" do
+      let(:site) { make_site("url" => "http://example.invalid") }
+      let(:page) { make_post("seo" => { "type" => "CreativeWork" }, "permalink" => "/foo/") }
+
+      it "outputs the mainEntityOfPage" do
+        expect(json_data["mainEntityOfPage"]["@type"]).to eql("WebPage")
+        expect(json_data["mainEntityOfPage"]["@id"]).to eql("http://example.invalid/foo/")
+      end
+    end
+
     context "with site.title" do
       let(:site) { make_site("title" => "Foo", "url" => "http://example.invalid") }
 


### PR DESCRIPTION
- [x]  Add Feature
- [X]  Add Docs
- [X]  Add Tests

This is just to add in the Author field (which is helpful for blog posts/articles when searching for articles + rich text formatting from Google). 

This also allows the [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) to pass without any errors for the type **BlogPosting** (now there are only warnings). 

BlogPosting was chosen instead of WebSite because of Google will treat this content type differently when it displays [Rich Cards](https://developers.google.com/search/docs/guides/search-gallery). 