### PR TITLE
Update title separator. Closes #121

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Jekyll plugin to add metadata tags for search engines and social networks to b
 
 Jekyll SEO Tag adds the following meta tags to your site:
 
-* Pages title (with site title appended when available)
+* Page title, with site title or description appended
 * Page description
 * Canonical URL
 * Next and previous URLs on paginated pages

--- a/lib/template.html
+++ b/lib/template.html
@@ -10,7 +10,7 @@
 
 {% if page.title and seo_site_title %}
   {% assign seo_title = seo_title | append:" | " | append: seo_site_title %}
-{% elsif site.description %}
+{% elsif site.description and seo_site_title %}
   {% assign seo_title = seo_title | append:" | " | append: site.description %}
 {% endif %}
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -9,9 +9,9 @@
 {% assign seo_title = page.title | default: seo_site_title %}
 
 {% if page.title and seo_site_title %}
-  {% assign seo_title = seo_title | append:" | " | append: seo_site_title %}
+  {% assign seo_title = page.title | append:" | " | append: seo_site_title %}
 {% elsif site.description and seo_site_title %}
-  {% assign seo_title = seo_title | append:" | " | append: site.description %}
+  {% assign seo_title = seo_site_title | append:" | " | append: site.description %}
 {% endif %}
 
 {% if page.seo and page.seo.name %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -5,21 +5,13 @@
 {% endif %}
 
 {% assign seo_site_title = site.title | default: site.name %}
+{% assign seo_page_title = page.title | default: seo_site_title %}
+{% assign seo_title = page.title | default: seo_site_title %}
 
-{% if page.title %}
-  {% assign seo_title = page.title %}
-  {% assign seo_page_title = page.title %}
-
-  {% if seo_site_title %}
-    {% assign seo_title = seo_title | append:" - " | append: seo_site_title %}
-  {% endif %}
-{% elsif seo_site_title %}
-  {% assign seo_title = seo_site_title %}
-  {% assign seo_page_title = seo_site_title %}
-
-  {% if site.description %}
-    {% assign seo_title = seo_title | append:" - " | append: site.description %}
-  {% endif %}
+{% if page.title and seo_site_title %}
+  {% assign seo_title = seo_title | append:" | " | append: seo_site_title %}
+{% elsif site.description %}
+  {% assign seo_title = seo_title | append:" | " | append: site.description %}
 {% endif %}
 
 {% if page.seo and page.seo.name %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -44,13 +44,47 @@ describe Jekyll::SeoTag do
       expect(output).to match(expected)
     end
 
+    context "with site.name" do
+      let(:site) { make_site("name" => "Site Name") }
+
+      it "builds the title with a page title and site name" do
+        expect(output).to match(%r!<title>foo \| Site Name</title>!)
+      end
+    end
+
     context "with site.title" do
       let(:site) { make_site("title" => "bar") }
 
       it "builds the title with a page title and site title" do
-        expect(output).to match(%r!<title>foo - bar</title>!)
+        expect(output).to match(%r!<title>foo \| bar</title>!)
       end
     end
+
+    context "with site.title and site.description" do
+      let(:site) { make_site("title" => "Site Title", "description" => "Site Description") }
+
+      it "builds the title with a page title and site title" do
+        expect(output).to match(%r!<title>foo \| Site Title</title>!)
+      end
+
+      it "does not build the title with the site description" do
+        expect(output).not_to match(%r!<title>foo \| Site Description</title>!)
+      end
+    end
+
+    context "with site.title and site.description" do
+      let(:site) { make_site("title" => "Site Title", "description" => "Site Description") }
+
+      it "builds the title with a page title and site title" do
+        expect(output).to match(%r!<title>foo \| Site Title</title>!)
+      end
+
+      it "does not build the title with the site description" do
+        expect(output).not_to match(%r!<title>Page Title \| Site Description</title>!)
+      end
+
+    end
+
   end
 
   context "with site.title" do
@@ -58,6 +92,14 @@ describe Jekyll::SeoTag do
 
     it "builds the title with only a site title" do
       expect(output).to match(%r!<title>Site title</title>!)
+    end
+  end
+
+  context "with site.title and site.description" do
+    let(:site) { make_site("title" => "Site Title", "description" => "Site Description") }
+
+    it "builds the title with site title and description" do
+      expect(output).to match(%r!<title>Site Title \| Site Description</title>!)
     end
   end
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -60,6 +60,14 @@ describe Jekyll::SeoTag do
       end
     end
 
+    context "with site.description" do
+      let(:site) { make_site("description" => "Site Description") }
+
+      it "builds the title without the site description" do
+        expect(output).not_to match(%r!<title>foo \| Site Description</title>!)
+      end
+    end
+
     context "with site.title and site.description" do
       let(:site) { make_site("title" => "Site Title", "description" => "Site Description") }
 
@@ -82,9 +90,7 @@ describe Jekyll::SeoTag do
       it "does not build the title with the site description" do
         expect(output).not_to match(%r!<title>Page Title \| Site Description</title>!)
       end
-
     end
-
   end
 
   context "with site.title" do


### PR DESCRIPTION
Replaces the "-" used as a title separator with "|".
Ref: https://moz.com/learn/seo/title-tag

Also updates docs to <s>specify title optional and fix errata</s> provide additional info.