### PR TITLE
No need to delete Jekyll's version from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ group :development, :test do
   versions.delete('ruby')
   versions.delete('jekyll-seo-tag')
   versions.delete('github-pages')
-  versions.delete('jekyll') # Remove this line when GitHub Pages supports 3.3.0
 
   versions.each do |dep, version|
     gem dep, version


### PR DESCRIPTION
🌸  Some spring cleanup as Github Pages now supports Jekyll 3.4.3 🌸 

/cc @benbalter 

