### PR TITLE
refactor(template): use og:image for twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Jekyll SEO Tag adds the following meta tags to your site:
 * Canonical URL
 * Next and previous URLs on paginated pages
 * [JSON-LD Site and post metadata](https://developers.google.com/structured-data/) for richer indexing
-* [Open graph](http://ogp.me/) title, description, site title, and URL (for Facebook, LinkedIn, etc.)
-* [Twitter summary card](https://dev.twitter.com/cards/overview) metadata
+* [Open Graph](http://ogp.me/) title, description, site title, and URL (for Facebook, LinkedIn, etc.)
+* [Twitter Summary Card](https://dev.twitter.com/cards/overview) metadata
 
 While you could theoretically add the necessary metadata tags yourself, Jekyll SEO Tag provides a battle-tested template of crowdsourced best-practices.
 
@@ -191,17 +191,14 @@ The following options can be set for any particular page. While the default opti
 For most users, setting `image: [path-to-image]` on a per-page basis should be enough. If you need more control over how images are represented, the `image` property can also be an object, with the following options:
 
 * `path` - The relative path to the image. Same as `image: [path-to-image]`
-* `twitter` - The relative path to a Twitter-specific image.
-* `facebook` - The relative path to a Facebook-specific image.
-* `height` - The height of the Facebook (`og:image`) image
-* `width` - The width of the Facebook (`og:image`) image
+* `height` - The height of the Open Graph (`og:image`) image
+* `width` - The width of the Open Graph (`og:image`) image
 
 You can use any of the above, optional properties, like so:
 
 ```yml
 image:
-  twitter: /img/twitter.png
-  facebook: /img/facebook.png
+  path: /img/twitter.png
   height: 100
   width: 100
 ```

--- a/lib/template.html
+++ b/lib/template.html
@@ -98,7 +98,7 @@
 {% endif %}
 
 {% if page.image %}
-  {% assign seo_page_image = page.image.path | default: page.image.facebook | default: page.image %}
+  {% assign seo_page_image = page.image.path | default: page.image.facebook | default: page.image.twitter | default: page.image %}
   {% unless seo_page_image contains "://" %}
     {% assign seo_page_image = seo_page_image | absolute_url %}
   {% endunless %}
@@ -132,17 +132,14 @@
 {% endif %}
 
 {% if seo_page_image %}
-<meta property="og:image" content="{{ seo_page_image }}" />
+
+  <meta property="og:image" content="{{ seo_page_image }}" />
   {% if page.image.height %}
     <meta property="og:image:height" content="{{ page.image.height }}" />
   {% endif %}
   {% if page.image.width %}
     <meta property="og:image:width" content="{{ page.image.width }}" />
   {% endif %}
-{% endif %}
-
-{% if page.image.twitter %}
-  <meta name="twitter:image" content="{{ page.image.twitter | absolute_url }}" />
 {% endif %}
 
 {% if page.date %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -124,7 +124,7 @@ describe Jekyll::SeoTag do
     context "with relative page.image as a string" do
       let(:page) { make_page("image" => "/img/foo.png") }
 
-      it "outputs the image" do
+      it "outputs an open graph image" do
         expected = '<meta property="og:image" content="http://example.invalid/img/foo.png" />'
         expect(output).to include(expected)
       end
@@ -133,7 +133,7 @@ describe Jekyll::SeoTag do
     context "with absolute page.image" do
       let(:page) { make_page("image" => "http://cdn.example.invalid/img/foo.png") }
 
-      it "outputs the image" do
+      it "outputs an open graph image" do
         expected = '<meta property="og:image" content="http://cdn.example.invalid/img/foo.png" />'
         expect(output).to include(expected)
       end
@@ -143,7 +143,7 @@ describe Jekyll::SeoTag do
       context "when given a path" do
         let(:page) { make_page("image" => { "path" => "/img/foo.png" }) }
 
-        it "outputs the image" do
+        it "outputs an open graph image" do
           expected = %r!<meta property="og:image" content="http://example.invalid/img/foo.png" />!
           expect(output).to match(expected)
         end
@@ -152,7 +152,7 @@ describe Jekyll::SeoTag do
       context "when given a facebook image" do
         let(:page) { make_page("image" => { "facebook" => "/img/facebook.png" }) }
 
-        it "outputs the image" do
+        it "outputs an open graph image" do
           expected = %r!<meta property="og:image" content="http://example.invalid/img/facebook.png" />!
           expect(output).to match(expected)
         end
@@ -161,17 +161,17 @@ describe Jekyll::SeoTag do
       context "when given a twitter image" do
         let(:page) { make_page("image" => { "twitter" => "/img/twitter.png" }) }
 
-        it "outputs the image" do
-          expected = %r!<meta name="twitter:image" content="http://example.invalid/img/twitter.png" />!
+        it "outputs an open graph image" do
+          expected = %r!<meta property="og:image" content="http://example.invalid/img/twitter.png" />!
           expect(output).to match(expected)
         end
       end
 
-      context "when given the image height and width" do
-        let(:image) { { "facebook" => "/img/foo.png", "height" => 1, "width" => 2 } }
+      context "when given an image height and width" do
+        let(:image) { { "path" => "/img/foo.png", "height" => 1, "width" => 2 } }
         let(:page) { make_page("image" => image) }
 
-        it "outputs the image" do
+        it "outputs an open graph image width and height" do
           expected = %r!<meta property="og:image:height" content="1" />!
           expect(output).to match(expected)
           expected = %r!<meta property="og:image:width" content="2" />!


### PR DESCRIPTION
#77 and #78 added support for different images on Twitter and Facebook, an advanced feature of SEO Tag Gem. The implementation has led to complications updating JSON-LD data in #151. Under Pareto principal (I also did a quick and dirty search on GitHub) we can reasonably assume this feature is not often used, and, as such, should be removed. The result of which simplifies template logic, offers a fallback experience by leveraging Twitter's use of `og:image` in place of `twitter:image` (sees [twitter card tag ref](https://dev.twitter.com/cards/markup)) and helps unblock #151.

Users can no longer specify a separate twitter and Facebook image. If both a Facebook (Open Graph) and Twitter image are provided in the `image` object, the Facebook image will take precedence.