### PR TITLE
Remove Rake dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,0 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-
-RSpec::Core::RakeTask.new(:spec)
-
-task :default => :spec

--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "jekyll", "~> 3.3"
   spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "html-proofer", "~> 3.6"
   spec.add_development_dependency "rubocop", "~> 0.48"

--- a/script/cibuild
+++ b/script/cibuild
@@ -2,6 +2,6 @@
 
 set -ex
 
-bundle exec rake spec
+bundle exec rspec
 bundle exec rubocop -S -D
 bundle exec gem build jekyll-seo-tag.gemspec


### PR DESCRIPTION
I'm pretty sure I added it before I knew what I was doing and don't think we need it to run `rake spec` when you can just run `rspec`.