### PR TITLE
Fix issue #183 image.itemtype

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -223,7 +223,16 @@
 {% endif %}
 
 {% if seo_page_image %}
+  {% if page.image.height && page.image.width %}
+    "image": {
+        "@type": "ImageObject",
+        "url": {{ seo_page_image | jsonify }},
+        "height": {{ page.image.height | jsonify }},
+        "width": {{ page.image.width | jsonify }}
+    },
+  {% else %}
     "image": {{ seo_page_image | jsonify }},
+  {% endif %}
 {% endif %}
 
 {% if page.date %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -196,7 +196,7 @@ describe Jekyll::SeoTag do
           expect(output).to match(expected)
         end
 
-        it "outputs the default image JSON item" do
+        it "outputs the image JSON item" do
           expect(json_data["image"]).to eql("http://example.invalid/img/foo.png")
         end
       end
@@ -230,7 +230,7 @@ describe Jekyll::SeoTag do
           expect(output).to match(expected)
         end
 
-        it "outputs the default image JSON object with dimensions" do
+        it "outputs the image JSON object with dimensions" do
           expect(json_data["image"]["url"]).to         eql("http://example.invalid/img/foo.png")
           expect(json_data["image"]["height"]).to eql(1)
           expect(json_data["image"]["width"]).to eql(2)

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -231,7 +231,7 @@ describe Jekyll::SeoTag do
         end
 
         it "outputs the image JSON object with dimensions" do
-          expect(json_data["image"]["url"]).to         eql("http://example.invalid/img/foo.png")
+          expect(json_data["image"]["url"]).to eql("http://example.invalid/img/foo.png")
           expect(json_data["image"]["height"]).to eql(1)
           expect(json_data["image"]["width"]).to eql(2)
         end

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -195,6 +195,10 @@ describe Jekyll::SeoTag do
           expected = %r!<meta property="og:image" content="http://example.invalid/img/foo.png" />!
           expect(output).to match(expected)
         end
+
+        it "outputs the default image JSON item" do
+          expect(json_data["image"]).to eql("http://example.invalid/img/foo.png")
+        end
       end
 
       context "when given a facebook image" do
@@ -224,6 +228,12 @@ describe Jekyll::SeoTag do
           expect(output).to match(expected)
           expected = %r!<meta property="og:image:width" content="2" />!
           expect(output).to match(expected)
+        end
+
+        it "outputs the default image JSON object with dimensions" do
+          expect(json_data["image"]["url"]).to         eql("http://example.invalid/img/foo.png")
+          expect(json_data["image"]["height"]).to eql(1)
+          expect(json_data["image"]["width"]).to eql(2)
         end
       end
     end


### PR DESCRIPTION
- [X]  Add Feature
- [X]  Add Tests

Fixes #183 by adding back the image.itemtype to the JSON-LD to pass the [Google Structured Data Testing](https://search.google.com/structured-data/testing-tool/u/0/) tool.

I've added the JSON-LD tests within the same context of the (already present) image tests as it made sense from a refactor standpoint.. let me know if you'd like that pulled to a different level. 