### PR TITLE
Fix for including name when author is passed by reference

### DIFF
--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -226,6 +226,7 @@ module Jekyll
       def author_hash(author_string)
         if site.data["authors"] && site.data["authors"][author_string]
           hash = site.data["authors"][author_string]
+          hash["name"]    ||= author_string
           hash["twitter"] ||= author_string
           hash
         else

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
 
     context "author" do
       let(:data) { {} }
-      let(:config) { { "author" => "author" } }
+      let(:config) { { "author" => "site_author" } }
       let(:site) do
         site = make_site(config)
         site.data = data
@@ -168,7 +168,10 @@ RSpec.describe Jekyll::SeoTag::Drop do
             if site_data_type == :with
               {
                 "authors" => {
-                  "author" => { "name" => "Author" },
+                  "author"        => { "name" => "data_author", "image" => "author.png" },
+                  "array_author"  => { "image" => "author.png" },
+                  "string_author" => { "image" => "author.png" },
+                  "site_author"   => { "image" => "author.png" },
                 },
               }
             else
@@ -177,29 +180,34 @@ RSpec.describe Jekyll::SeoTag::Drop do
           end
 
           {
-            :string       => { "author" => "author" },
-            :array        => { "authors" => %w(author author2) },
+            :string       => { "author" => "string_author" },
+            :array        => { "authors" => %w(array_author author2) },
             :empty_string => { "author" => "" },
             :nil          => { "author" => nil },
-            :hash         => { "author" => { "name" => "author" } },
+            :hash         => { "author" => { "name" => "hash_author" } },
           }.each do |author_type, data|
             context "with author as #{author_type}" do
               let(:page_meta) { data }
+              let(:expected_author) do
+                "#{author_type}_author".sub("nil_", "site_").sub("empty_string_", "site_")
+              end
 
               it "returns a hash" do
                 expect(subject.author).to be_a(Hash)
               end
 
               it "returns the name" do
-                if site_data_type == :with && author_type != :hash
-                  expect(subject.author["name"]).to eql("Author")
-                else
-                  expect(subject.author["name"]).to eql("author")
-                end
+                expect(subject.author["name"]).to eql(expected_author)
               end
 
               it "returns the twitter handle" do
-                expect(subject.author["twitter"]).to eql("author")
+                expect(subject.author["twitter"]).to eql(expected_author)
+              end
+
+              if site_data_type == :with && author_type != :hash
+                it "returns the image" do
+                  expect(subject.author["image"]).to eql("author.png")
+                end
               end
             end
           end


### PR DESCRIPTION
If author metadata is stored in a datafile without an explicit name, the previous behavior was to fall back to the author name passed as the data key. This PR preserves that behavior, and adds tests to ensure it continues to work going forward.

Typically, you'd add `author: benbalter` to a post's metadata, and then in in `_authors.yml` have a `benbalter` key, with values like `name: Ben Balter`.

It was possible, however to have `author: Ben Balter` in your post, and then have a `Ben Balter` key in your author's file (without duplicating the name).

This PR makes it such that if a `name` key does not exist in the resolved author hash, it uses the lookup key (e.g., `benbalter` in the first example and `Ben Balter` in the second) as the name.