### PR TITLE
Remove dynamic logic from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,3 @@ require "json"
 require "open-uri"
 
 gemspec
-
-group :development, :test do
-  versions = JSON.parse(open("https://pages.github.com/versions.json").read)
-  versions.delete("ruby")
-  versions.delete("jekyll-seo-tag")
-  versions.delete("github-pages")
-
-  versions.each do |dep, version|
-    gem dep, version
-  end
-end


### PR DESCRIPTION
Someone shortsighted (read: me) added logic to dynamically pull the Gemfile from GitHub Page's production version over in https://github.com/jekyll/jekyll-seo-tag/pull/47.

The unintended side effect of that, however, is that any time you boot the Ruby VM (bundle, run tests, use the gem locally, etc.) you need internet access, which makes developing on slow WiFi very painful.

This removes the dynamic logic so local development can be managed by the Gemfile instead.