### PR TITLE
Guard against the author's Twitter handle being Nil when stripping @'s

### DIFF
--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -88,7 +88,7 @@ module Jekyll
                    end
 
           author["twitter"] ||= author["name"]
-          author["twitter"].delete! "@"
+          author["twitter"].delete! "@" if author["twitter"]
           author.to_liquid
         end
       end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -261,6 +261,15 @@ RSpec.describe Jekyll::SeoTag::Drop do
           end
         end
 
+        # See https://github.com/jekyll/jekyll-seo-tag/issues/202
+        context "without an author name or handle" do
+          let(:page_meta) { { "author" => { "foo" => "bar" } } }
+
+          it "dosen't blow up" do
+            expect(subject.author["twitter"]).to be_nil
+          end
+        end
+
         context "with an explicit handle" do
           let(:page_meta) do
             {


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll-seo-tag/issues/202.