### PR TITLE
Handle page title consisting of only whitespace

### DIFF
--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -33,7 +33,11 @@ module Jekyll
 
       # Page title without site title or description appended
       def page_title
-        @page_title ||= format_string(page["title"] || site_title)
+        @page_title ||= if page["title"] && !page["title"].empty?
+                          format_string(page["title"])
+                        else
+                          format_string(site_title)
+                        end
       end
 
       # Page title with site title or description appended


### PR DESCRIPTION
Hi, thanks for maintaining this plugin!

This is a bit of an edge case, but currently, this breaks if `page['title']` is set but consists of only whitespace.

Basically ` @page_title ||= format_string(page["title"] || site_title)` ends up setting `@page_title` to `nil` because `page["title"]` is defined, but calling `format_string` on it returns `nil`.

Then down in the `#title` method, this condition: `if page["title"] && site_title` will evaluate to `true` but then blow up because it tries to concatenate `page_title` which is `nil`.

This should correct that!