### PR TITLE
Guard against empty title or description strings

### DIFF
--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -67,9 +67,9 @@ module Jekyll
       end
 
       def description
-        @description ||= format_string(
-          page["description"] || page["excerpt"] || site["description"]
-        )
+        @description ||= begin
+          format_string(page["description"] || page["excerpt"]) || site_description
+        end
       end
 
       # Returns a nil or a hash representing the author

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -62,7 +62,7 @@ module Jekyll
                 elsif site_social["name"]
                   format_string site_social["name"]
                 elsif site_title
-                  format_string site_title
+                  site_title
                 end
       end
 

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -31,18 +31,22 @@ module Jekyll
         @site_title ||= format_string(site["title"] || site["name"])
       end
 
+      def site_description
+        format_string site["description"]
+      end
+
       # Page title without site title or description appended
       def page_title
-        @page_title ||= format_string(page["title"] || site_title)
+        @page_title ||= format_string(page["title"]) || site_title
       end
 
       # Page title with site title or description appended
       def title
         @title ||= begin
-          if page["title"] && site_title
+          if site_title && page_title != site_title
             page_title + TITLE_SEPARATOR + site_title
-          elsif site["description"] && site_title
-            site_title + TITLE_SEPARATOR + format_string(site["description"])
+          elsif site_description && site_title
+            site_title + TITLE_SEPARATOR + site_description
           else
             page_title || site_title
           end

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -32,7 +32,7 @@ module Jekyll
       end
 
       def site_description
-        format_string site["description"]
+        @site_description ||= format_string site["description"]
       end
 
       # Page title without site title or description appended

--- a/spec/fixtures/_posts/2017-01-03-.md
+++ b/spec/fixtures/_posts/2017-01-03-.md
@@ -1,0 +1,6 @@
+---
+---
+
+# A post without a title
+
+*See* https://github.com/jekyll/jekyll-seo-tag/commit/4f80ea50b773d1995985e35a8a63806516c353c4#commitcomment-22010563

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -97,6 +97,40 @@ RSpec.describe Jekyll::SeoTag::Drop do
           expect(subject.title).to eql("site title")
         end
       end
+
+      context "without a page or site title" do
+        let(:page)  { make_page }
+        let(:site)  { make_site }
+
+        it "returns nil" do
+          expect(subject.title).to be_nil
+        end
+      end
+
+      context "with an empty page title" do
+        let(:page_meta) { { :title => "" } }
+
+        it "builds the title" do
+          expect(subject.title).to eql("site title")
+        end
+      end
+
+      context "with an empty site title" do
+        let(:config) { { :title => "" } }
+
+        it "builds the title" do
+          expect(subject.title).to eql("page title")
+        end
+      end
+
+      context "with an empty page and site title" do
+        let(:page_meta) { { :title => "" } }
+        let(:config) { { :title => "" } }
+
+        it "returns nil" do
+          expect(subject.title).to be_nil
+        end
+      end
     end
   end
 
@@ -135,7 +169,25 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
     end
 
-    context "description" do
+    context "site description" do
+      context "with a site description" do
+        let(:config) { { :description => "site description " } }
+
+        it "returns the site discription" do
+          expect(subject.site_description).to eql("site description")
+        end
+      end
+
+      context "without a site description" do
+        let(:site) { make_site }
+
+        it "returns nil" do
+          expect(subject.site_description).to be_nil
+        end
+      end
+    end
+
+    context "page description" do
       context "with a page description" do
         let(:page_meta) { { "description"=> "page description" } }
 


### PR DESCRIPTION
An alternate approach to https://github.com/jekyll/jekyll-seo-tag/pull/204 and to address the comments on https://github.com/jekyll/jekyll-seo-tag/commit/4f80ea50b773d1995985e35a8a63806516c353c4#commitcomment-22010563, this PR defensively codes against `title` or `description` on the site or page level being an empty string.

The problem is if a value is `""`, `page["key"]` will return `""`, but `format_string(page["key"])` will return nil, meaning `format_string(page["key"]) + "s" if page["key"]` while intuitively right, will cause an unknown method or no implicit conversion error because `""` is truthy in Ruby.