### PR TITLE
use canonical_url specified in page if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,30 @@ defaults:
 ### SmartyPants Titles
 
 Titles will be processed using [Jekyll's `smartify` filter](https://jekyllrb.com/docs/templates/). This will use SmartyPants to translate plain ASCII punctuation into "smart" typographic punctuation. This will not render or strip any Markdown you may be using in a page title.
+
+### Setting customized Canonical URL
+
+You can set custom Canonical URL for a page by specifying canonical_url option in page front-matter.
+E.g., you have the following in the page's front matter:
+```yml
+layout: post
+title: Title of Your Post
+canonical_url: 'https://github.com/jekyll/jekyll-seo-tag/'
+```
+
+Which will generate canonical_url with specified link in canonical_url.
+```html
+<link rel="canonical" href="https://github.com/jekyll/jekyll-seo-tag/" />
+```
+
+If no canonical_url option was specified, then uses page url for generating canonical_url.
+E.g., you have not specified canonical_url in front-matter:
+```yml
+layout: post
+title: Title of Your Post
+```
+
+Which will generate following canonical_url:
+```html
+<link rel="canonical" href="http://yoursite.com/title-of-your-post" />
+```

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -183,7 +183,11 @@ module Jekyll
 
       def canonical_url
         @canonical_url ||= begin
-          filters.absolute_url(page["url"]).to_s.gsub(%r!/index\.html$!, "/")
+          if page["canonical_url"].present?
+            page["canonical_url"]
+          else
+            filters.absolute_url(page["url"]).to_s.gsub(%r!/index\.html$!, "/")
+          end
         end
       end
 

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -183,7 +183,7 @@ module Jekyll
 
       def canonical_url
         @canonical_url ||= begin
-          if !page["canonical_url"].to_s.empty?
+          unless page["canonical_url"].to_s.empty?
             page["canonical_url"]
           else
             filters.absolute_url(page["url"]).to_s.gsub(%r!/index\.html$!, "/")

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -183,7 +183,7 @@ module Jekyll
 
       def canonical_url
         @canonical_url ||= begin
-          if page["canonical_url"].present?
+          if !page["canonical_url"].to_s.empty?
             page["canonical_url"]
           else
             filters.absolute_url(page["url"]).to_s.gsub(%r!/index\.html$!, "/")

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -183,10 +183,10 @@ module Jekyll
 
       def canonical_url
         @canonical_url ||= begin
-          unless page["canonical_url"].to_s.empty?
-            page["canonical_url"]
-          else
+          if page["canonical_url"].to_s.empty?
             filters.absolute_url(page["url"]).to_s.gsub(%r!/index\.html$!, "/")
+          else
+            page["canonical_url"]
           end
         end
       end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -626,21 +626,21 @@ RSpec.describe Jekyll::SeoTag::Drop do
   end
 
   context "canonical url" do
-    let(:config) { { :url => "http://example.com" } } 
-    
+    let(:config) { { :url => "http://example.com" } }
+
     context "when canonical url is specified for a page" do
       let(:canonical_url) { "https://github.com/jekyll/jekyll-seo-tag/" }
       let(:page_meta) { { "title" => "page title", "canonical_url" => canonical_url } }
-      
+
       it "uses specified canonical url" do
         expect(subject.canonical_url).to eq(canonical_url)
       end
     end
 
     context "when canonical url is not specified for a page" do
-      
+
       it "uses site specific canonical url" do
-        expect(subject.canonical_url).to eq("http://example.com/page-title.html")
+        expect(subject.canonical_url).to eq("http://example.com/page.html")
       end
     end
   end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -627,8 +627,8 @@ RSpec.describe Jekyll::SeoTag::Drop do
 
   context "canonical url" do
     context "when canonical url is specified for a page" do
-      let(:page) { make_page( { "title" => "page title", "canonical_url" => "https://github.com/jekyll/jekyll-seo-tag/"} ) }
-      let(:canonical_url) { 'https://github.com/jekyll/jekyll-seo-tag/' }
+      let(:page) { make_page({ "title" => "page title", "canonical_url" => "https://github.com/jekyll/jekyll-seo-tag/" }) }
+      let(:canonical_url) { "https://github.com/jekyll/jekyll-seo-tag/" }
       it "uses specified canonical url" do
         puts subject.canonical_url
         expect(subject.canonical_url).to eq(canonical_url)
@@ -636,11 +636,10 @@ RSpec.describe Jekyll::SeoTag::Drop do
     end
 
     context "when canonical url is not specified for a page" do
-      let(:canonical_url) { 'https://github.com/jekyll/jekyll-seo-tag/' }
+      let(:canonical_url) { "https://github.com/jekyll/jekyll-seo-tag/" }
       it "uses site specific canonical url" do
         expect(subject.canonical_url).not_to eq(canonical_url)
       end
     end
   end
-  
 end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -626,18 +626,21 @@ RSpec.describe Jekyll::SeoTag::Drop do
   end
 
   context "canonical url" do
+    let(:config) { { :url => "http://example.com" } } 
+    
     context "when canonical url is specified for a page" do
-      let(:page) { make_page({ "title" => "page title", "canonical_url" => "https://github.com/jekyll/jekyll-seo-tag/" }) }
       let(:canonical_url) { "https://github.com/jekyll/jekyll-seo-tag/" }
+      let(:page_meta) { { "title" => "page title", "canonical_url" => canonical_url } }
+      
       it "uses specified canonical url" do
         expect(subject.canonical_url).to eq(canonical_url)
       end
     end
 
     context "when canonical url is not specified for a page" do
-      let(:canonical_url) { "https://github.com/jekyll/jekyll-seo-tag/" }
+      
       it "uses site specific canonical url" do
-        expect(subject.canonical_url).not_to eq(canonical_url)
+        expect(subject.canonical_url).to eq("http://example.com/page-title.html")
       end
     end
   end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -638,7 +638,6 @@ RSpec.describe Jekyll::SeoTag::Drop do
     end
 
     context "when canonical url is not specified for a page" do
-
       it "uses site specific canonical url" do
         expect(subject.canonical_url).to eq("http://example.com/page.html")
       end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -630,7 +630,6 @@ RSpec.describe Jekyll::SeoTag::Drop do
       let(:page) { make_page({ "title" => "page title", "canonical_url" => "https://github.com/jekyll/jekyll-seo-tag/" }) }
       let(:canonical_url) { "https://github.com/jekyll/jekyll-seo-tag/" }
       it "uses specified canonical url" do
-        puts subject.canonical_url
         expect(subject.canonical_url).to eq(canonical_url)
       end
     end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -624,4 +624,23 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
     end
   end
+
+  context "canonical url" do
+    context "when canonical url is specified for a page" do
+      let(:page) { make_page( { "title" => "page title", "canonical_url" => "https://github.com/jekyll/jekyll-seo-tag/"} ) }
+      let(:canonical_url) { 'https://github.com/jekyll/jekyll-seo-tag/' }
+      it "uses specified canonical url" do
+        puts subject.canonical_url
+        expect(subject.canonical_url).to eq(canonical_url)
+      end
+    end
+
+    context "when canonical url is not specified for a page" do
+      let(:canonical_url) { 'https://github.com/jekyll/jekyll-seo-tag/' }
+      it "uses site specific canonical url" do
+        expect(subject.canonical_url).not_to eq(canonical_url)
+      end
+    end
+  end
+  
 end


### PR DESCRIPTION
assign the canonical url to canonical_url specified by user in page otherwise use default generated url.