### PR TITLE
feat(image): Add meta twitter image

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -29,6 +29,7 @@
 
 {% if seo_tag.image %}
   <meta property="og:image" content="{{ seo_tag.image.path }}" />
+  <meta property="twitter:image" content="{{ seo_tag.image.path }}" />
   {% if seo_tag.image.height %}
     <meta property="og:image:height" content="{{ seo_tag.image.height }}" />
   {% endif %}


### PR DESCRIPTION
# Description

In documentation for twitter card we need to add meta `twitter:image`
See: [https://dev.twitter.com/cards/types/summary](https://dev.twitter.com/cards/types/summary)

# Validate

See new meta `twitter:image` in page when image.path is config