### PR TITLE
Configure default Twitter summary card type

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,11 +6,16 @@ The SEO tag will respect any of the following if included in your site's `_confi
 * `description` - A short description (e.g., A blog dedicated to reviewing cat gifs)
 * `url` - The full URL to your site. Note: `site.github.url` will be used by default.
 * `author` - global author information (see below)
-* `twitter:username` - The site's Twitter handle. You'll want to describe it like so:
+* `image` - global image
+
+* `twitter` - The following properties are avaliable:
+  * `twitter:username` - The site's Twitter handle
+  * `twitter:card` - The global card setting (`summary`, `summary_large_image`)
 
   ```yml
   twitter:
     username: benbalter
+    card: summary
   ```
 
 * `facebook` - The following properties are available:
@@ -65,3 +70,4 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `image` - URL to an image associated with the post, page, or document (e.g., `/assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see below)
 * `lang` - Page-, post-, or document-specific language information
+* `twittercard` - Page-, post-, oe document-specific card size

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,6 +12,8 @@ The SEO tag will respect any of the following if included in your site's `_confi
   * `twitter:username` - The site's Twitter handle
   * `twitter:card` - The global card setting (`summary`, `summary_large_image`)
 
+You'll want to describe one or more like so:
+
   ```yml
   twitter:
     username: benbalter

--- a/lib/template.html
+++ b/lib/template.html
@@ -51,7 +51,11 @@
 
 {% if site.twitter %}
   {% if seo_tag.image %}
-    <meta name="twitter:card" content="summary_large_image" />
+      {% if site.twitter.smallSummary %}
+        <meta name="twitter:card" content="summary" />
+      {% else %}
+        <meta name="twitter:card" content="summary_large_image" />
+      {% endif %}
   {% else %}
     <meta name="twitter:card" content="summary" />
   {% endif %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -60,12 +60,8 @@
 {% endif %}
 
 {% if site.twitter %}
-  {% if seo_tag.image %}
-      {% if site.twitter.smallSummary %}
-        <meta name="twitter:card" content="summary" />
-      {% else %}
-        <meta name="twitter:card" content="summary_large_image" />
-      {% endif %}
+  {% if seo_tag.image or site.image %}
+    <meta name="twitter:card" content="{{ seo_tag.twittercard | default: site.twitter.card | default: "summary_large_image" }}" />
   {% else %}
     <meta name="twitter:card" content="summary" />
   {% endif %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -35,6 +35,16 @@
   {% if seo_tag.image.width %}
     <meta property="og:image:width" content="{{ seo_tag.image.width }}" />
   {% endif %}
+{% else %}
+  {% if site.image %}
+    <meta property="og:image" content="{{ site.image.path }}" />
+    {% if site.image.height %}
+      <meta property="og:image:height" content="{{ site.image.height }}" />
+    {% endif %}
+    {% if site.image.width %}
+      <meta property="og:image:width" content="{{ site.image.width }}" />
+    {% endif %}
+  {% endif %}
 {% endif %}
 
 {% if page.date %}


### PR DESCRIPTION
Add ability at site level to not use the large twitter summary

Current rather yucky workaround is doing this:

```
{% capture seo %}
{% seo %}
{% endcapture %}

{{ seo | replace: "summary_large_image", "summary" }}
```
fix #84