### PR TITLE
Configure default Twitter summary card type (V2)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,7 +44,7 @@ The SEO tag will respect any of the following if included in your site's `_confi
       - https://github.com/benbalter
       - https://keybase.io/benbalter
     ```
-
+tre
 * `google_site_verification` for verifying ownership via Google webmaster tools
 * Alternatively, verify ownership with several services at once using the following format:
 
@@ -65,3 +65,6 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `image` - URL to an image associated with the post, page, or document (e.g., `/assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see below)
 * `lang` - Page-, post-, or document-specific language information
+* `twitterCardType` - The type of twitter card to use
+
+*Note:* Front matter defaults can be used as described [here](https://github.com/BlythMeister/jekyll-seo-tag/blob/TwitterCard/docs/advanced-usage.md#setting-a-default-image)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,7 +44,7 @@ The SEO tag will respect any of the following if included in your site's `_confi
       - https://github.com/benbalter
       - https://keybase.io/benbalter
     ```
-tre
+
 * `google_site_verification` for verifying ownership via Google webmaster tools
 * Alternatively, verify ownership with several services at once using the following format:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,4 +67,4 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `lang` - Page-, post-, or document-specific language information
 * `twitterCardType` - The type of twitter card to use
 
-*Note:* Front matter defaults can be used as described [here](https://github.com/BlythMeister/jekyll-seo-tag/blob/TwitterCard/docs/advanced-usage.md#setting-a-default-image)
+*Note:* Front matter defaults can be used for any of the above values as described [here] with an image example (https://github.com/BlythMeister/jekyll-seo-tag/blob/TwitterCard/docs/advanced-usage.md#setting-a-default-image)

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -53,6 +53,10 @@ module Jekyll
         end
       end
 
+      def twitterCardType
+        @twitterCardType ||= format_string page["twitterCardType"]
+      end
+      
       def name
         return @name if defined?(@name)
         @name = if seo_name

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -52,10 +52,6 @@ module Jekyll
           end
         end
       end
-
-      def twitterCardType
-        @twitterCardType ||= format_string page["twitterCardType"]
-      end
       
       def name
         return @name if defined?(@name)

--- a/lib/template.html
+++ b/lib/template.html
@@ -51,7 +51,7 @@
 
 {% if site.twitter %}
   {% if seo_tag.image %}
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="{{ seo_tag.twitterCardType | default: "summary_large_image" }}" />
   {% else %}
     <meta name="twitter:card" content="summary" />
   {% endif %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -51,7 +51,7 @@
 
 {% if site.twitter %}
   {% if seo_tag.image %}
-    <meta name="twitter:card" content="{{ seo_tag.twitterCardType | default: "summary_large_image" }}" />
+    <meta name="twitter:card" content="{{ page.twitterCardType | default: "summary_large_image" }}" />
   {% else %}
     <meta name="twitter:card" content="summary" />
   {% endif %}


### PR DESCRIPTION
Update to #222 with cleaner history.

Original details:

Add ability at site level to not use the large twitter summary

Current rather yucky workaround is doing this:

```
{% capture seo %}
{% seo %}
{% endcapture %}

{{ seo | replace: "summary_large_image", "summary" }}
```
fix #84