### PR TITLE
Configure default Twitter summary card type (V2)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,11 +6,15 @@ The SEO tag will respect any of the following if included in your site's `_confi
 * `description` - A short description (e.g., A blog dedicated to reviewing cat gifs)
 * `url` - The full URL to your site. Note: `site.github.url` will be used by default.
 * `author` - global author information (see below)
-* `twitter:username` - The site's Twitter handle. You'll want to describe it like so:
+
+* `twitter` - The following properties are available:
+  * `twitter:username` - The site's Twitter handle
+  * `twitter:card` - The site's default card type
 
   ```yml
   twitter:
     username: benbalter
+    card: summary_large_image
   ```
 
 * `facebook` - The following properties are available:
@@ -66,6 +70,5 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `image` - URL to an image associated with the post, page, or document (e.g., `/assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see below)
 * `lang` - Page-, post-, or document-specific language information
-* `twitter_image_small` - Page-, post-, or document-specific flag to use small twitter image
   
 *Note:* Front matter defaults can be used for any of the above values as described in advanced usage with an image example.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,8 +14,8 @@ The SEO tag will respect any of the following if included in your site's `_confi
   ```yml
   twitter:
     username: benbalter
-    card: summary_large_image
-  ```
+    card: summary
+  ```
 
 * `facebook` - The following properties are available:
   * `facebook:app_id` - a Facebook app ID for Facebook insights

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,3 +65,6 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `image` - URL to an image associated with the post, page, or document (e.g., `/assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see below)
 * `lang` - Page-, post-, or document-specific language information
+* `twitterCardType` - The type of twitter card to use
+  
+*Note:* Front matter defaults can be used for any of the above values as described in advanced usage with an image example.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,6 +65,6 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `image` - URL to an image associated with the post, page, or document (e.g., `/assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see below)
 * `lang` - Page-, post-, or document-specific language information
-* `twitterCardType` - The type of twitter card to use
+* `twitter_image_small` - Page-, post-, or document-specific flag to use small twitter image
   
 *Note:* Front matter defaults can be used for any of the above values as described in advanced usage with an image example.

--- a/lib/template.html
+++ b/lib/template.html
@@ -53,11 +53,7 @@
 
 {% if site.twitter %}
   {% if seo_tag.image %}
-    {% if page.twitter_image_small or post.twitter_image_small %}
-      <meta name="twitter:card" content="summary" />
-    {% else %}
-      <meta name="twitter:card" content="summary_large_image" />
-    {% endif %}
+    <meta name="twitter:card" content="{{ page.twitter.card | default: site.twitter.card | default: "summary_large_image" }}" />
   {% else %}
     <meta name="twitter:card" content="summary" />
   {% endif %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -51,10 +51,10 @@
 
 {% if site.twitter %}
   {% if seo_tag.image %}
-    {% if page.twitter_image_small %}
+    {% if page.twitter_image_small or post.twitter_image_small %}
       <meta name="twitter:card" content="summary" />
     {% else %}
-        <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:card" content="summary_large_image" />
     {% endif %}
   {% else %}
     <meta name="twitter:card" content="summary" />

--- a/lib/template.html
+++ b/lib/template.html
@@ -51,7 +51,11 @@
 
 {% if site.twitter %}
   {% if seo_tag.image %}
-    <meta name="twitter:card" content="{{ page.twitterCardType | default: "summary_large_image" }}" />
+    {% if page.twitter_image_small %}
+      <meta name="twitter:card" content="summary" />
+    {% else %}
+        <meta name="twitter:card" content="summary_large_image" />
+    {% endif %}
   {% else %}
     <meta name="twitter:card" content="summary" />
   {% endif %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -51,7 +51,7 @@
 
 {% if site.twitter %}
   {% if seo_tag.image %}
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="{{ page.twitterCardType | default: "summary_large_image" }}" />
   {% else %}
     <meta name="twitter:card" content="summary" />
   {% endif %}


### PR DESCRIPTION
Update to #222 with cleaner history.

Original details:

Add ability at site level to not use the large twitter summary

Current rather yucky workaround is doing this:

```
{% capture seo %}
{% seo %}
{% endcapture %}

{{ seo | replace: "summary_large_image", "summary" }}
```
fix #84