### PR TITLE
Ensure site.data.authors is properly formatted before attempting to retrieve author meta

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,5 +12,7 @@
       
       {{ content }}
     </div>
+    <script src="{{ "assets/javascript/anchor-js/anchor.min.js" | relative_url }}"></script>
+    <script>anchors.add();</script>
   </body>
 </html>

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -246,6 +246,10 @@ module Jekyll
         site_author_hash(author_string) || { "name" => author_string }
       end
 
+      # Given a string representing the current document's author, attempt
+      # to retrieve additional metadata from site.data.authors, if present
+      #
+      # Returns the author hash
       def site_author_hash(author_string)
         return unless site.data["authors"] && site.data["authors"].is_a?(Hash)
         author_hash = site.data["authors"][author_string]

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -239,15 +239,20 @@ module Jekyll
         end
       end
 
+      # Given a string representing the current document's author, return
+      # a normalized hash representing that author. Will try to pull from
+      # site.authors if present and in the proper format.
       def author_hash(author_string)
-        if site.data["authors"] && site.data["authors"][author_string]
-          hash = site.data["authors"][author_string]
-          hash["name"]    ||= author_string
-          hash["twitter"] ||= author_string
-          hash
-        else
-          { "name" => author_string }
-        end
+        site_author_hash(author_string) || { "name" => author_string }
+      end
+
+      def site_author_hash(author_string)
+        return unless site.data["authors"] && site.data["authors"].is_a?(Hash)
+        author_hash = site.data["authors"][author_string]
+        return unless author_hash.is_a?(Hash)
+        author_hash["name"] ||= author_string
+        author_hash["twitter"] ||= author_string
+        author_hash
       end
 
       def seo_name

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -231,6 +231,15 @@ RSpec.describe Jekyll::SeoTag::Drop do
         site
       end
 
+      context "with site.authors as an array" do
+        let("data") { ["foo", "bar"] }
+        let(:page_meta) { {"author" => "foo"} }
+
+        it "doesn't error" do
+          expect(subject.author).to eql("")
+        end
+      end
+
       %i[with without].each do |site_data_type|
         context "#{site_data_type} site.author data" do
           let(:data) do

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -232,11 +232,11 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
 
       context "with site.authors as an array" do
-        let("data") { ["foo", "bar"] }
+        let("data") { { "authors" => ["foo", "bar"] } }
         let(:page_meta) { {"author" => "foo"} }
 
         it "doesn't error" do
-          expect(subject.author).to eql("")
+          expect(subject.author).to eql({"name"=>"foo", "twitter"=>"foo"})
         end
       end
 

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -232,20 +232,20 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
 
       context "with site.authors as an array" do
-        let("data") { { "authors" => ["foo", "bar"] } }
-        let(:page_meta) { {"author" => "foo"} }
+        let("data") { { "authors" => %w(foo bar) } }
+        let(:page_meta) { { "author" => "foo" } }
 
         it "doesn't error" do
-          expect(subject.author).to eql({"name"=>"foo", "twitter"=>"foo"})
+          expect(subject.author).to eql({ "name" => "foo", "twitter" => "foo" })
         end
       end
 
       context "with site.authors[author] as string" do
         let("data") { { "authors" => { "foo" => "bar" } } }
-        let(:page_meta) { {"author" => "foo"} }
+        let(:page_meta) { { "author" => "foo" } }
 
         it "doesn't error" do
-          expect(subject.author).to eql({"name"=>"foo", "twitter"=>"foo"})
+          expect(subject.author).to eql({ "name" => "foo", "twitter" => "foo" })
         end
       end
 

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -240,6 +240,15 @@ RSpec.describe Jekyll::SeoTag::Drop do
         end
       end
 
+      context "with site.authors[author] as string" do
+        let("data") { { "authors" => { "foo" => "bar" } } }
+        let(:page_meta) { {"author" => "foo"} }
+
+        it "doesn't error" do
+          expect(subject.author).to eql({"name"=>"foo", "twitter"=>"foo"})
+        end
+      end
+
       %i[with without].each do |site_data_type|
         context "#{site_data_type} site.author data" do
           let(:data) do


### PR DESCRIPTION
If `site.data.authors` is an array, or if `site.data.authors[author]` is anything other than a Hash, the build will error out. 

This PR makes `Drop#author_hash` a bit more robust by ensuring `site.data.authors` and `site.data.authors[author]` is a hash before attempting to access it or add additional elements. 

The user-facing functionality should be identical, but more robust.

This problem arises when Jekyll SEO Tag is included (by default in some cases) on GitHub Pages, and the user has a `_data/authors.yml` that was not formatted to work with Jekyll SEO tag.