### PR TITLE
Fix for image.path causing an invalid url error

### DIFF
--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -168,7 +168,8 @@ module Jekyll
         image["path"] ||= image["facebook"] || image["twitter"]
         return @image = nil unless image["path"]
 
-        unless absolute_url? image["path"]
+        # absolute_url? will return nil for an invalid URL
+        if absolute_url?(image["path"]) == false
           image["path"] = filters.absolute_url image["path"]
         end
 

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -563,7 +563,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
         let(:image) { ":" }
 
         it "returns nil" do
-          expect(subject.image["path"]).to eql("/:")
+          expect(subject.image["path"]).to eql(":")
         end
       end
 


### PR DESCRIPTION
If `image.path` is invalid, `absolute_url?` will return `nil` which is falsy. Explicitly look for `false` before we try to make the URL absolute to avoid an upstream error.