### PR TITLE
gems: is deprecated in current Jekyll version of github-pages

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@
 2. Add the following to your site's `_config.yml`:
 
   ```yml
-  gems:
+  plugins:
     - jekyll-seo-tag
   ```
 


### PR DESCRIPTION
Jekyll 3.5:

Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.