### PR TITLE
Cache parsed template

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -31,7 +31,7 @@ module Jekyll
 
     def render(context)
       @context = context
-      template.render!(payload, info)
+      SeoTag.template.render!(payload, info)
     end
 
     private
@@ -63,19 +63,23 @@ module Jekyll
       }
     end
 
-    def template
-      @template ||= Liquid::Template.parse template_contents
-    end
-
-    def template_contents
-      @template_contents ||= begin
-        File.read(template_path).gsub(MINIFY_REGEX, "")
+    class << self
+      def template
+        @template ||= Liquid::Template.parse template_contents
       end
-    end
 
-    def template_path
-      @template_path ||= begin
-        File.expand_path "./template.html", File.dirname(__FILE__)
+      private
+
+      def template_contents
+        @template_contents ||= begin
+          File.read(template_path).gsub(MINIFY_REGEX, "")
+        end
+      end
+
+      def template_path
+        @template_path ||= begin
+          File.expand_path "./template.html", File.dirname(__FILE__)
+        end
       end
     end
   end


### PR DESCRIPTION
I added debug output to SeoTag#template and realized that for *every* page with SEO tag called, we're (A) calculating the template path, (B) reading in the template, and (C) parsing it. 

Of course, we only have one template, and that template stays the same between pages (crazy how templates work, right?), so we may as well cache it on the class, rather than the instance.

This PR exposes SeoTag.template, a memoized class variable, so we parse the template on SEO tag's first call, and not on each subsequent call.

On my personal site, build time went from about 16 seconds to about 14.