### PR TITLE
Pass the unified drop to the template rather than an ad-hoc payload

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -44,12 +44,12 @@ module Jekyll
     end
 
     def payload
-      {
+      # site_payload is an instance of UnifiedPayloadDrop. See https://git.io/v5ajm
+      @payload ||= context.registers[:site].site_payload.merge({
         "page"      => context.registers[:page],
-        "site"      => context.registers[:site].site_payload["site"],
         "paginator" => context["paginator"],
         "seo_tag"   => drop,
-      }
+      })
     end
 
     def drop

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -45,7 +45,7 @@ module Jekyll
 
     def payload
       # site_payload is an instance of UnifiedPayloadDrop. See https://git.io/v5ajm
-      @payload ||= context.registers[:site].site_payload.merge({
+      Jekyll::Utils.deep_merge_hashes(context.registers[:site].site_payload, {
         "page"      => context.registers[:page],
         "paginator" => context["paginator"],
         "seo_tag"   => drop,

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -20,10 +20,6 @@ module Jekyll
         Jekyll::SeoTag::VERSION
       end
 
-      def jekyll_version
-        Jekyll::VERSION
-      end
-
       # Should the `<title>` tag be generated for this page?
       def title?
         return false unless title

--- a/lib/template.html
+++ b/lib/template.html
@@ -3,7 +3,7 @@
   <title>{{ seo_tag.title }}</title>
 {% endif %}
 
-<meta name="generator" content="Jekyll v{{ seo_tag.jekyll_version }}" />
+<meta name="generator" content="Jekyll v{{ jekyll.version }}" />
 
 {% if seo_tag.page_title %}
   <meta property="og:title" content="{{ seo_tag.page_title }}" />

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Jekyll::SeoTag do
+  let(:config)    { { "title" => "site title" } }
+  let(:page_meta) { {} }
+  let(:page)      { make_page(page_meta) }
+  let(:site)      { make_site(config) }
+  let(:render_context) { make_context(:page => page, :site => site) }
+  let(:text) { "" }
+  let(:tag_name) { "github_edit_link" }
+  let(:tokenizer) { Liquid::Tokenizer.new("") }
+  let(:parse_context) { Liquid::ParseContext.new }
+  let(:rendered) { subject.render(render_context) }
+  let(:payload) { subject.send(:payload) }
+
+  subject do
+    tag = described_class.parse(tag_name, text, tokenizer, parse_context)
+    tag.instance_variable_set("@context", render_context)
+    tag
+  end
+
+  before do
+    Jekyll.logger.log_level = :error
+  end
+
+  it "returns the template" do
+    expect(described_class.template).to be_a(Liquid::Template)
+  end
+
+  context "payload" do
+    it "contains the drop" do
+      expect(payload["seo_tag"]).to be_a(Jekyll::SeoTag::Drop)
+    end
+
+    it "contains the Jekyll drop" do
+      expect(payload["jekyll"]).to be_a(Jekyll::Drops::JekyllDrop)
+    end
+
+    it "contains the page" do
+      expect(payload["page"]).to be_a(Jekyll::Page)
+    end
+
+    it "contains the site" do
+      expect(payload["site"]).to be_a(Jekyll::Drops::SiteDrop)
+    end
+  end
+
+  it "renders" do
+    expected = "<!-- Begin Jekyll SEO tag v#{described_class::VERSION} -->"
+    expect(rendered).to match(expected)
+  end
+end


### PR DESCRIPTION
As mentioned in https://github.com/jekyll/jekyll-seo-tag/pull/236#discussion_r137122176, when we wanted access to the `jekyll` universal namespace in the template, we had to add it as a one-off. 

Users expect certain globals to exist at render time. Things like `jekyll`, `site`, and `page`. We could expose each to the template manually, or, we could use the existing Jekyll::UnifiedDrop (what Jekyll uses to render pages), and merge in our custom metadata, just as Jekyll would before rendering a template.

Practically, this means that the template now has access to the JekyllDrop in the top-level `jekyll` namespace, but it also means that if Jekyll adds additional properties to the UnifiedDrop, we'll get them for free.

My thinking is that we may want to allow users to override the template with say, `_layouts/seo-tag.html`, and providing them with a predictable, intuitive, and consistent render context could only help get us one step closer.

Finally, I realized the Jekyll::SeoTag itself had integration tests, but no unit tests, so I added a few quick unit tests to ensure the payload contained the payload we'd expect (in addition to the integration test for the Jekyll version).