### PR TITLE
Fix: Consistently use self-closing tags

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -45,10 +45,10 @@
 {% endif %}
 
 {% if paginator.previous_page %}
-  <link rel="prev" href="{{ paginator.previous_page_path | absolute_url }}">
+  <link rel="prev" href="{{ paginator.previous_page_path | absolute_url }}" />
 {% endif %}
 {% if paginator.next_page %}
-  <link rel="next" href="{{ paginator.next_page_path | absolute_url }}">
+  <link rel="next" href="{{ paginator.next_page_path | absolute_url }}" />
 {% endif %}
 
 {% if site.twitter %}
@@ -81,19 +81,19 @@
 
 {% if site.webmaster_verifications %}
   {% if site.webmaster_verifications.google %}
-    <meta name="google-site-verification" content="{{ site.webmaster_verifications.google }}">
+    <meta name="google-site-verification" content="{{ site.webmaster_verifications.google }}" />
   {% endif %}
 
   {% if site.webmaster_verifications.bing %}
-    <meta name="msvalidate.01" content="{{ site.webmaster_verifications.bing }}">
+    <meta name="msvalidate.01" content="{{ site.webmaster_verifications.bing }}" />
   {% endif %}
 
   {% if site.webmaster_verifications.alexa %}
-    <meta name="alexaVerifyID" content="{{ site.webmaster_verifications.alexa }}">
+    <meta name="alexaVerifyID" content="{{ site.webmaster_verifications.alexa }}" />
   {% endif %}
 
   {% if site.webmaster_verifications.yandex %}
-    <meta name="yandex-verification" content="{{ site.webmaster_verifications.yandex }}">
+    <meta name="yandex-verification" content="{{ site.webmaster_verifications.yandex }}" />
   {% endif %}
 {% elsif site.google_site_verification %}
   <meta name="google-site-verification" content="{{ site.google_site_verification }}" />

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -577,8 +577,8 @@ EOS
     let(:context) { make_context({}, "paginator" => paginator) }
 
     it "outputs pagination links" do
-      expect(output).to match(%r!<link rel="prev" href="/foo">!)
-      expect(output).to match(%r!<link rel="next" href="/bar">!)
+      expect(output).to match(%r!<link rel="prev" href="/foo" />!)
+      expect(output).to match(%r!<link rel="next" href="/bar" />!)
     end
   end
 
@@ -596,22 +596,22 @@ EOS
       let(:site) { make_site("webmaster_verifications" => site_verifications) }
 
       it "outputs google verification meta" do
-        expected = %r!<meta name="google-site-verification" content="foo">!
+        expected = %r!<meta name="google-site-verification" content="foo" />!
         expect(output).to match(expected)
       end
 
       it "outputs bing verification meta" do
-        expected = %r!<meta name="msvalidate.01" content="bar">!
+        expected = %r!<meta name="msvalidate.01" content="bar" />!
         expect(output).to match(expected)
       end
 
       it "outputs alexa verification meta" do
-        expected = %r!<meta name="alexaVerifyID" content="baz">!
+        expected = %r!<meta name="alexaVerifyID" content="baz" />!
         expect(output).to match(expected)
       end
 
       it "outputs yandex verification meta" do
-        expected = %r!<meta name="yandex-verification" content="bat">!
+        expected = %r!<meta name="yandex-verification" content="bat" />!
         expect(output).to match(expected)
       end
     end


### PR DESCRIPTION
This PR

* [x] consistently uses self-closing tags

💁‍♂️ Sometimes they are closed, sometimes they aren't - better to be consistent, I think.