### PR TITLE
Fix: Run 'bundle exec rubocop -a'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+# frozen_string_literal: true
 
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "jekyll", "~> 3.3"
   spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "html-proofer", "~> 3.6"
+  spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "rubocop", "~> 0.48"
 end

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "jekyll"
 require "jekyll-seo-tag/version"
 

--- a/lib/jekyll-seo-tag/author_drop.rb
+++ b/lib/jekyll-seo-tag/author_drop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   class SeoTag
     # A drop representing the current page's author

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   class SeoTag
     class Drop < Jekyll::Drops::Drop

--- a/lib/jekyll-seo-tag/filters.rb
+++ b/lib/jekyll-seo-tag/filters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   class SeoTag
     class Filters

--- a/lib/jekyll-seo-tag/image_drop.rb
+++ b/lib/jekyll-seo-tag/image_drop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   class SeoTag
     # A drop representing the page image

--- a/lib/jekyll-seo-tag/json_ld.rb
+++ b/lib/jekyll-seo-tag/json_ld.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   class SeoTag
     # This module is deprecated, but is included in the Gem to avoid a breaking

--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   class SeoTag
     class JSONLDDrop < Jekyll::Drops::Drop

--- a/lib/jekyll-seo-tag/url_helper.rb
+++ b/lib/jekyll-seo-tag/url_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   class SeoTag
     # Mixin to share common URL-related methods between class

--- a/lib/jekyll-seo-tag/version.rb
+++ b/lib/jekyll-seo-tag/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Prevent bundler errors
 module Liquid; class Tag; end; end
 

--- a/spec/jekyll_seo_tag/author_drop_spec.rb
+++ b/spec/jekyll_seo_tag/author_drop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Jekyll::SeoTag::AuthorDrop do
   let(:data) { {} }
   let(:config) { { "author" => "site_author" } }

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Jekyll::SeoTag::Drop do
   let(:config)    { { "title" => "site title" } }
   let(:page_meta) { { "title" => "page title" } }

--- a/spec/jekyll_seo_tag/filters_spec.rb
+++ b/spec/jekyll_seo_tag/filters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Jekyll::SeoTag::Filters do
   let(:page)      { make_page }
   let(:site)      { make_site }

--- a/spec/jekyll_seo_tag/image_drop_spec.rb
+++ b/spec/jekyll_seo_tag/image_drop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Jekyll::SeoTag::ImageDrop do
   let(:config)    { { "title" => "site title" } }
   let(:image)     { nil }

--- a/spec/jekyll_seo_tag/json_ld_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Jekyll::SeoTag::JSONLDDrop do
   let(:author) { "author" }
   let(:image) { "image" }

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Jekyll::SeoTag do
   let(:page)      { make_page }
   let(:site)      { make_site }

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Jekyll::SeoTag do
   let(:config)    { { "title" => "site title" } }
   let(:page_meta) { {} }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "jekyll"
 require "jekyll-seo-tag"


### PR DESCRIPTION
This PR

* [x] runs `bundle exec rubocop -a` to fix coding standard issues

Somewhat related to #246.

💁‍♂️ Some of the builds are apparently failing because of these unfixed issues.