### PR TITLE
Strip null values from JSON-LD hash

### DIFF
--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -73,6 +73,10 @@ module Jekyll
       alias_method :mainEntityOfPage, :main_entity
       private :main_entity
 
+      def to_json
+        to_h.reject { |_k, v| v.nil? }.to_json
+      end
+
       private
 
       attr_reader :page_drop

--- a/spec/jekyll_seo_tag/json_ld_drop_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_drop_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
     let(:metadata) { {} }
 
     it "does not return null values as json" do
-      expect(subject.to_json).to_not match(/:null/)
+      expect(subject.to_json).to_not match(%r!:null!)
     end
   end
 end

--- a/spec/jekyll_seo_tag/json_ld_drop_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_drop_spec.rb
@@ -152,4 +152,12 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
     expect(subject).to have_key("url")
     expect(subject["url"]).to eql("/page.html")
   end
+
+  context "with null values" do
+    let(:metadata) { {} }
+
+    it "does not return null values as json" do
+      expect(subject.to_json).to_not match(/:null/)
+    end
+  end
 end

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -338,6 +338,10 @@ EOS
       it "minifies JSON-LD" do
         expect(output).to_not match(%r!{.*?\s.*?}!)
       end
+
+      it "removes null values from JSON-LD" do
+        expect(output).to_not match(/:null/)
+      end
     end
   end
 

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -340,7 +340,7 @@ EOS
       end
 
       it "removes null values from JSON-LD" do
-        expect(output).to_not match(/:null/)
+        expect(output).to_not match(%r!:null!)
       end
     end
   end


### PR DESCRIPTION
If we're minifying the JSON-LD, it doesn't make sense to include null values in the output, introduce when we moved to JSONLDDrop.

This PR adds a custom `to_json` method to the drop (which liquid calls via `jsonify`) to strip null values from the hash (which the spec says to ignore).

Fixes https://github.com/jekyll/jekyll-seo-tag/issues/233.