### PR TITLE
Include page number in title

### DIFF
--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -182,7 +182,7 @@ module Jekyll
       end
 
       def page_number
-        return if !@context["paginator"] || !@context["paginator"]["page"]
+        return unless @context["paginator"] && @context["paginator"]["page"]
 
         current = @context["paginator"]["page"]
         total = @context["paginator"]["total_pages"]

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -53,6 +53,12 @@ module Jekyll
             page_title || site_title
           end
         end
+
+        if page_number
+          return page_number + @title
+        end
+
+        @title
       end
 
       def name
@@ -173,6 +179,17 @@ module Jekyll
 
       def homepage_or_about?
         page["url"] =~ HOMEPAGE_OR_ABOUT_REGEX
+      end
+
+      def page_number
+        return if !@context["paginator"] || !@context["paginator"]["page"]
+
+        current = @context["paginator"]["page"]
+        total = @context["paginator"]["total_pages"]
+
+        if current > 1
+          return "Page #{current} of #{total} for "
+        end
       end
 
       attr_reader :context


### PR DESCRIPTION
Per [Moz's article "Pagination: Best Practices for SEO & User Experience"](https://moz.com/blog/pagination-best-practices-for-seo-user-experience) it's not ideal to use the same title with pagination. This change follows Moz's suggestion and appends "Page X of Y for" to the beginning of the `<title>` when on page 2 of deeper.