### PR TITLE
Fix markdown for a code snippet and some indents

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,8 +14,8 @@ The SEO tag will respect any of the following if included in your site's `_confi
   ```yml
   twitter:
     username: benbalter
-    card: summary
-  ```
+    card: summary
+  ```
 
 * `facebook` - The following properties are available:
   * `facebook:app_id` - a Facebook app ID for Facebook insights

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,12 +24,12 @@ The SEO tag will respect any of the following if included in your site's `_confi
 
   You'll want to describe one or more like so:
 
-   ```yml
+  ```yml
   facebook:
     app_id: 1234
     publisher: 1234
     admins: 1234
-   ```
+  ```
 
 * `logo` - URL to a site-wide logo (e.g., `/assets/your-company-logo.png`) - If you would like the "publisher" property to be present, you must add this field to your site's configuration, during the validation of the structured data by Google web master tools, if the `logo` field is not validated, you will find errors inherent to the publisher in the [structured datas test](https://search.google.com/structured-data/testing-tool/u/0/)
 * `social` - For [specifying social profiles](https://developers.google.com/structured-data/customize/social-profiles). The following properties are available:
@@ -47,7 +47,7 @@ The SEO tag will respect any of the following if included in your site's `_confi
       - https://plus.google.com/+BenBalter
       - https://github.com/benbalter
       - https://keybase.io/benbalter
-    ```
+  ```
 
 * `google_site_verification` for verifying ownership via Google webmaster tools
 * Alternatively, verify ownership with several services at once using the following format:
@@ -70,5 +70,5 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `image` - URL to an image associated with the post, page, or document (e.g., `/assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see [Advanced usage](advanced-usage.md#author-information))
 * `lang` - Page-, post-, or document-specific language information
-  
+
 *Note:* Front matter defaults can be used for any of the above values as described in advanced usage with an image example.


### PR DESCRIPTION
I found that a document has a broken code snippet and some inconsistent indents.

| before | after |
| --- | --- |
| ![screenshot 2018-05-11 10 17 14](https://user-images.githubusercontent.com/15693305/39901618-9bebdd98-5504-11e8-8469-f2f803830c4d.png) | ![screenshot 2018-05-11 10 17 28](https://user-images.githubusercontent.com/15693305/39901619-9c0f7c08-5504-11e8-9bb6-9c5a0dc05f4c.png) |