### PR TITLE
add tests for twitter.card types

### DIFF
--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -424,11 +424,34 @@ EOS
       end
 
       context "with page.image" do
-        let(:page) { make_page("image" => "/img/foo.png") }
+        context "without *.twitter.card" do
+          let(:page) { make_page("image" => "/img/foo.png") }
 
-        it "outputs summary card with large image" do
-          expected = %r!<meta name="twitter:card" content="summary_large_image" />!
-          expect(output).to match(expected)
+          it "outputs summary card with large image" do
+            expected = %r!<meta name="twitter:card" content="summary_large_image" />!
+            expect(output).to match(expected)
+          end
+        end
+
+        context "with page.twitter.card" do
+          let(:page_twitter) { { "card" => "summary" } }
+          let(:page) { make_page("image" => "/img/foo.png", "twitter" => page_twitter) }
+
+          it "outputs summary card with small image" do
+            expected = %r!<meta name="twitter:card" content="summary" />!
+            expect(output).to match(expected)
+          end
+        end
+
+        context "with site.twitter.card" do
+          let(:site_twitter) { { "username" => "jekyllrb", "card" => "summary" } }
+          let(:site) { make_site("twitter" => site_twitter) }
+          let(:page) { make_page("image" => "/img/foo.png") }
+
+          it "outputs summary card with small image" do
+            expected = %r!<meta name="twitter:card" content="summary" />!
+            expect(output).to match(expected)
+          end
         end
       end
 


### PR DESCRIPTION
I wrote test codes for twitter card type configuration (https://github.com/jekyll/jekyll-seo-tag/pull/225).
Please merge if these tests are beneficial.

I wrote tests because I could not change twitter card type of my github page which theme is choosed with "repository settings" webUI.
After wrote this, I noticed that https://github.com/jekyll/jekyll-seo-tag/pull/225 was merged only 9 days ago.