### PR TITLE
Update Page description to include page number

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,9 @@
+## HEAD
+
+### Bug Fixes
+
+  * Update url of schema website (#296)
+
 ## 2.5.0 / 2018-05-18
 
   * Docs: Prevent GitHub Pages from processing Liquid raw tag (#276)

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -34,7 +34,7 @@ module Jekyll
       end
 
       def site_description
-        @site_description ||= format_string site["description"]
+        @site_description ||= page_description
       end
 
       # Page title without site title or description appended
@@ -54,9 +54,7 @@ module Jekyll
           end
         end
 
-        if page_number
-          return page_number + @title
-        end
+        return "#{page_number} for #{@title}" if page_number
 
         @title
       end
@@ -187,9 +185,7 @@ module Jekyll
         current = @context["paginator"]["page"]
         total = @context["paginator"]["total_pages"]
 
-        if current > 1
-          return "Page #{current} of #{total} for "
-        end
+        "Page #{current} of #{total}" if current > 1
       end
 
       attr_reader :context
@@ -230,6 +226,15 @@ module Jekyll
         else
           {}
         end
+      end
+
+      def page_description
+        return [
+          format_string(site['description']),
+          page_number
+        ].join(' - ') if page_number.present?
+
+        format_string(site['description'])
       end
     end
   end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
   let(:site)      { make_site(config) }
   let(:context)   { make_context(:page => page, :site => site) }
   let(:text) { "" }
+
   subject { described_class.new(text, context) }
 
   before do
@@ -185,6 +186,23 @@ RSpec.describe Jekyll::SeoTag::Drop do
 
         it "returns nil" do
           expect(subject.site_description).to be_nil
+        end
+      end
+
+      context 'with multiple pages' do
+        let(:config) { {
+          :description => "My site description",
+          :title => 'My site title',
+          :paginator => {
+            :page => 2,
+            :total_pages => 3
+          }
+        }}
+
+        let(:site) { make_site(config) }
+
+        it 'returns site description with page number' do
+          expect(subject.site_description).to eql("My site description - Page 2 of 3")
         end
       end
     end


### PR DESCRIPTION
Issue: https://github.com/jekyll/jekyll-seo-tag/issues/265
Add page number to description if it is not first page.
First Page Description: 'My Description'
Other pages: 'My Description - Page 1 of 2'