### PR TITLE
Lint Ruby code with rubocop-jekyll gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
+require: rubocop-jekyll
 inherit_gem:
-  jekyll: .rubocop.yml
+  rubocop-jekyll: .rubocop.yml
 
 AllCops:
   TargetRubyVersion: 2.3

--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "html-proofer", "~> 3.7"
   spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "rubocop", "~> 0.56.0"
+  spec.add_development_dependency "rubocop-jekyll", "~> 0.1.0"
 end

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -47,11 +47,12 @@ module Jekyll
 
     def payload
       # site_payload is an instance of UnifiedPayloadDrop. See https://git.io/v5ajm
-      Jekyll::Utils.deep_merge_hashes(context.registers[:site].site_payload, {
+      Jekyll::Utils.deep_merge_hashes(
+        context.registers[:site].site_payload,
         "page"      => context.registers[:page],
         "paginator" => context["paginator"],
-        "seo_tag"   => drop,
-      })
+        "seo_tag"   => drop
+      )
     end
 
     def drop

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -6,8 +6,8 @@ module Jekyll
       include Jekyll::SeoTag::UrlHelper
 
       TITLE_SEPARATOR = " | "
-      FORMAT_STRING_METHODS = %i[
-        markdownify strip_html normalize_whitespace escape_once
+      FORMAT_STRING_METHODS = [
+        :markdownify, :strip_html, :normalize_whitespace, :escape_once,
       ].freeze
       HOMEPAGE_OR_ABOUT_REGEX = %r!^/(about/)?(index.html?)?$!
 
@@ -43,6 +43,7 @@ module Jekyll
       end
 
       # Page title with site title or description appended
+      # rubocop:disable Metrics/CyclomaticComplexity
       def title
         @title ||= begin
           if site_title && page_title != site_title
@@ -54,12 +55,11 @@ module Jekyll
           end
         end
 
-        if page_number
-          return page_number + @title
-        end
+        return page_number + @title if page_number
 
         @title
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       def name
         return @name if defined?(@name)
@@ -187,9 +187,7 @@ module Jekyll
         current = @context["paginator"]["page"]
         total = @context["paginator"]["total_pages"]
 
-        if current > 1
-          return "Page #{current} of #{total} for "
-        end
+        return "Page #{current} of #{total} for " if current > 1
       end
 
       attr_reader :context


### PR DESCRIPTION
Inheriting Rubocop config from the `jekyll` gem *may not always* guarantee an error-free build especially when the inherited config may not be compatible with the Rubocop version currently being used.

[`rubocop-jekyll`](https://github.com/ashmaroli/rubocop-jekyll/releases/tag/v0.1.0) is a welcome solution because it can be updated and shipped frequently independent of Jekyll releases. (`v0.1.0` is locked to and compatible with `Rubocop >= 0.57.2 < 0.58` )

P.S. Since this is a development dependency, it will not be installed automatically and as such shouldn't be a security concern for `github-pages`