### PR TITLE
Do not cache the drop payload for SeoTag

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -56,7 +56,20 @@ module Jekyll
     end
 
     def drop
-      @drop ||= Jekyll::SeoTag::Drop.new(@text, @context)
+      # TODO: Modify following comment once Jekyll 4.0 ships.
+      # ------------------------------------------------------------------------------------------
+      # Jekyll 4.0 is probably going to cache parsed Liquid Templates which is going to break the
+      # rendered output from this tag since there's going to be just a single instance of this
+      # class per {% seo %} in a template, (especially when the tag is used as part of an include).
+      # -------------------------------------------------------------------------------------------
+      #
+      # FIXME: Switch to using `if Gem::Version.new(Jekyll::VERSION) >= Gem::Version.new("4.0.0")`
+      #        once Jekyll 4.0 ships.
+      if context.registers[:site].liquid_renderer.respond_to?(:cache)
+        Jekyll::SeoTag::Drop.new(@text, @context)
+      else
+        @drop ||= Jekyll::SeoTag::Drop.new(@text, @context)
+      end
     end
 
     def info


### PR DESCRIPTION
For compatibility with Jekyll 4.0.. and current `jekyll:master`..