### PR TITLE
Correct RuboCop offenses in spec files

### DIFF
--- a/spec/jekyll_seo_tag/author_drop_spec.rb
+++ b/spec/jekyll_seo_tag/author_drop_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Jekyll::SeoTag::AuthorDrop do
     end
   end
 
-  %i[with without].each do |site_data_type|
+  [:with, :without].each do |site_data_type|
     context "#{site_data_type} site.author data" do
       let(:data) do
         if site_data_type == :with

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
     end
 
     context "the about page" do
-      let(:page) { make_page({ "permalink" => "/about/" }) }
+      let(:page) { make_page("permalink" => "/about/") }
 
       it "is a website" do
         expect(subject.type).to eql("WebSite")

--- a/spec/jekyll_seo_tag/json_ld_drop_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_drop_spec.rb
@@ -91,12 +91,12 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
       it "returns the image as a hash" do
         expect(subject).to have_key("image")
         expect(subject["image"]).to be_a(Hash)
-        expect(subject["image"]).to eql({
+        expect(subject["image"]).to eql(
           "@type"  => "imageObject",
           "url"    => "/image",
           "height" => 5,
-          "width"  => 10,
-        })
+          "width"  => 10
+        )
       end
     end
   end

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -299,16 +299,16 @@ RSpec.describe Jekyll::SeoTag do
 
       it "minifies the output" do
         version = Jekyll::SeoTag::VERSION
-        expected = <<-EOS
-<!-- Begin Jekyll SEO tag v#{version} -->
-<title>Foo</title>
-<meta name="generator" content="Jekyll v#{Jekyll::VERSION}" />
-<meta property="og:title" content="Foo" />
-<meta property="og:locale" content="en_US" />
-<link rel="canonical" href="http://example.invalid/page.html" />
-<meta property="og:url" content="http://example.invalid/page.html" />
-<meta property="og:site_name" content="Foo" />
-EOS
+        expected = <<~HTML
+          <!-- Begin Jekyll SEO tag v#{version} -->
+          <title>Foo</title>
+          <meta name="generator" content="Jekyll v#{Jekyll::VERSION}" />
+          <meta property="og:title" content="Foo" />
+          <meta property="og:locale" content="en_US" />
+          <link rel="canonical" href="http://example.invalid/page.html" />
+          <meta property="og:url" content="http://example.invalid/page.html" />
+          <meta property="og:site_name" content="Foo" />
+        HTML
         expect(output).to match(expected)
       end
     end


### PR DESCRIPTION
`rubocop-jekyll-0.4.0` allows detecting RuboCop Offenses in spec files..