### PR TITLE
Relax version constraint on Bundler

### DIFF
--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jekyll", "~> 3.3"
-  spec.add_development_dependency "bundler", ">= 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
   spec.add_development_dependency "html-proofer", "~> 3.7"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.4"

--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jekyll", "~> 3.3"
+  spec.add_development_dependency "bundler", ">= 1.15"
   spec.add_development_dependency "html-proofer", "~> 3.7"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.4"

--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jekyll", "~> 3.3"
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "html-proofer", "~> 3.7"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.4"

--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jekyll", "~> 3.3"
-  spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
   spec.add_development_dependency "html-proofer", "~> 3.7"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.4"


### PR DESCRIPTION
To support Bundler v1.x series as well as its v2.x series.