### PR TITLE
Twitter Image and Title

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -54,6 +54,7 @@
 {% if site.twitter %}
   {% if seo_tag.image %}
     <meta name="twitter:card" content="{{ page.twitter.card | default: site.twitter.card | default: "summary_large_image" }}" />
+    <meta property="twitter:image" content="{{ seo_tag.image.path }}" />
   {% else %}
     <meta name="twitter:card" content="summary" />
   {% endif %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -59,6 +59,7 @@
     <meta name="twitter:card" content="summary" />
   {% endif %}
 
+  <meta property="twitter:title" content="{{ seo_tag.page_title }}" />
   <meta name="twitter:site" content="@{{ site.twitter.username | replace:"@","" }}" />
 
   {% if seo_tag.author.twitter %}


### PR DESCRIPTION
I noticed Twitter is no longer pulling the image from og:image. 

This change adds the twitter:image meta tag if an image exists on the post. 

It also adds the twitter:title meta tag as well.