### PR TITLE
use example.com for example URL

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -138,5 +138,5 @@ title: Title of Your Post
 
 Which will generate following canonical_url:
 ```html
-<link rel="canonical" href="http://yoursite.com/title-of-your-post" />
+<link rel="canonical" href="https://example.com/title-of-your-post" />
 ```


### PR DESCRIPTION
it's specially designed for examples - no need to point to http://yoursite.com :-)