### PR TITLE
Prefer site.tagline to site.description for page title

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,8 +2,9 @@
 
 The SEO tag will respect any of the following if included in your site's `_config.yml` (and simply not include them if they're not defined):
 
-* `title` - Your site's title (e.g., Ben's awesome site, The GitHub Blog, etc.)
-* `description` - A short description (e.g., A blog dedicated to reviewing cat gifs)
+* `title` - Your site's title (e.g., Ben's awesome site, The GitHub Blog, etc.), used as part of the title tag like 'page.title | title'.
+* `tagline` - A short description (e.g., A blog dedicated to reviewing cat gifs), used as part of the title tag of the home page like 'title | tagline'.
+* `description` - A longer description used for the description meta tag. Also used as fallback for pages that don't provide their own `description` and as part of the home page title tag if `tagline` is not defined.
 * `url` - The full URL to your site. Note: `site.github.url` will be used by default.
 * `author` - global author information (see [Advanced usage](advanced-usage.md#author-information))
 

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -34,6 +34,10 @@ module Jekyll
         @site_title ||= format_string(site["title"] || site["name"])
       end
 
+      def site_tagline
+        @site_tagline ||= format_string site["tagline"]
+      end
+
       def site_description
         @site_description ||= format_string site["description"]
       end
@@ -43,6 +47,10 @@ module Jekyll
         @page_title ||= format_string(page["title"]) || site_title
       end
 
+      def site_tagline_or_description
+        site_tagline || site_description
+      end
+
       # Page title with site title or description appended
       # rubocop:disable Metrics/CyclomaticComplexity
       def title
@@ -50,7 +58,7 @@ module Jekyll
           if site_title && page_title != site_title
             page_title + TITLE_SEPARATOR + site_title
           elsif site_description && site_title
-            site_title + TITLE_SEPARATOR + site_description
+            site_title + TITLE_SEPARATOR + site_tagline_or_description
           else
             page_title || site_title
           end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -84,6 +84,17 @@ RSpec.describe Jekyll::SeoTag::Drop do
         end
       end
 
+      context "with a site tagline but no page title" do
+        let(:page)  { make_page }
+        let(:config) do
+          { "title" => "site title", "description" => "site description", "tagline" => "site tagline" }
+        end
+
+        it "builds the title" do
+          expect(subject.title).to eql("site title | site tagline")
+        end
+      end
+
       context "with just a page title" do
         let(:site)  { make_site }
 


### PR DESCRIPTION
Using `site.description` as part of the title for pages that don't have an explicit title --- typically the landing page of a site --- leads to very long page titles. The `site.description` field is typically used for search engine or social media previews, which are 100+ characters long, making it a bad choice for the title for pages that use the description field in this way.

This PR changes the behavior of this plugin to prefer `site.tagline` over `site.description` when it is available. Sites that do not define a `site.tagline` are not affected by this. 

The name `site.tagline` was chosen as it served [the same role][1] in the Hyde theme. 

[1]: https://github.com/poole/hyde/blob/master/_includes/head.html