### PR TITLE
Removal of `meta name="author"`

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -9,10 +9,6 @@
   <meta property="og:title" content="{{ seo_tag.page_title }}" />
 {% endif %}
 
-{% if seo_tag.author.name %}
-  <meta name="author" content="{{ seo_tag.author.name }}" />
-{% endif %}
-
 <meta property="og:locale" content="{{ seo_tag.page_lang | replace:'-','_' }}" />
 
 {% if seo_tag.description %}


### PR DESCRIPTION
I've removed the `<meta name="author" />` tag from `template.html`

The reasons are is that this specific `meta` tag has been dropped back in 2014.
The correct way to use the `authorship` tag is through the `rel="author"` tag,

Example:
```
<a href="/authorname/archive" rel="author">Author Name</a>
```

However,  the `meta name="author"` is primarily used as `citation`
```
<meta name="citation_title" content="Crystal structure of squid rhodopsin" />
<meta name="citation_publication_date" content="1999" />
<meta name="citation_author" content="Murakami, Midori" />
<meta name="citation_author" content="Kouyama, Tsutomu" />
<meta name="citation_pdf_url" content="crist_struct.pdf" />
```

Sources:
- [Special tags currently supported by Google](https://support.google.com/webmasters/answer/79812?hl=en)
- [Moz on "author" tag](https://moz.com/blog/the-ultimate-guide-to-seo-meta-tags)
- [Google Authorship Markup](https://webmasters.googleblog.com/2011/06/authorship-markup-and-web-search.html)
- [Google Scholar Metadata & the `author` tag](https://www.monperrus.net/martin/accurate+bibliographic+metadata+and+google+scholar)