### PR TITLE
Render og:locale meta only when defined explicitly

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,7 +60,7 @@ webmaster_verifications:
   baidu: 1234
 ```
 
-* `lang` - The locale these tags are marked up in. Of the format `language_TERRITORY`. Default is `en_US`.
+* `locale` - The locale these tags are marked up in. Of the format `language_TERRITORY`. Default is `en_US`.
 
 The SEO tag will respect the following YAML front matter if included in a post, page, or document:
 
@@ -68,6 +68,6 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `description` - A short description of the page's content
 * `image` - URL to an image associated with the post, page, or document (e.g., `/assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see [Advanced usage](advanced-usage.md#author-information))
-* `lang` - Page-, post-, or document-specific language information
+* `locale` - Page-, post-, or document-specific locale information
 
 *Note:* Front matter defaults can be used for any of the above values as described in advanced usage with an image example.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,7 +66,8 @@ The following properties are available:
     yandex: 1234
     baidu: 1234
   ```
-* `locale` - The locale these tags are marked up in. Of the format `language_TERRITORY`. Default is `en_US`.
+* `locale` - The locale these tags are marked up in. Of the format `language_TERRITORY`. Default is `en_US`. Takes priority
+over existing config key `lang`.
 
 The SEO tag will respect the following YAML front matter if included in a post, page, or document:
 
@@ -74,6 +75,6 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `description` - A short description of the page's content
 * `image` - URL to an image associated with the post, page, or document (e.g., `/assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see [Advanced usage](advanced-usage.md#author-information))
-* `locale` - Page-, post-, or document-specific locale information
+* `locale` - Page-, post-, or document-specific locale information. Takes priority over existing front matter attribute `lang`.
 
 *Note:* Front matter defaults can be used for any of the above values as described in advanced usage with an image example.

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -164,6 +164,12 @@ module Jekyll
         @page_lang ||= page["lang"] || site["lang"] || "en_US"
       end
 
+      def page_locale
+        return @page_locale if defined?(@page_locale)
+
+        @page_locale = page["locale"] && page["locale"].tr("-", "_")
+      end
+
       def canonical_url
         @canonical_url ||= begin
           if page["canonical_url"].to_s.empty?

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -165,9 +165,7 @@ module Jekyll
       end
 
       def page_locale
-        return @page_locale if defined?(@page_locale)
-
-        @page_locale = page["locale"] && page["locale"].tr("-", "_")
+        @page_locale ||= (page["locale"] || site["locale"] || page_lang).tr("-", "_")
       end
 
       def canonical_url

--- a/lib/template.html
+++ b/lib/template.html
@@ -13,7 +13,9 @@
   <meta name="author" content="{{ seo_tag.author.name }}" />
 {% endif %}
 
-<meta property="og:locale" content="{{ seo_tag.page_lang | replace:'-','_' }}" />
+{% if seo_tag.page_locale %}
+  <meta property="og:locale" content="{{ seo_tag.page_locale }}" />
+{% endif %}
 
 {% if seo_tag.description %}
   <meta name="description" content="{{ seo_tag.description }}" />

--- a/lib/template.html
+++ b/lib/template.html
@@ -13,9 +13,7 @@
   <meta name="author" content="{{ seo_tag.author.name }}" />
 {% endif %}
 
-{% if seo_tag.page_locale %}
-  <meta property="og:locale" content="{{ seo_tag.page_locale }}" />
-{% endif %}
+<meta property="og:locale" content="{{ seo_tag.page_locale }}" />
 
 {% if seo_tag.description %}
   <meta name="description" content="{{ seo_tag.description }}" />


### PR DESCRIPTION
Render `og:locale` meta attribute only if `{{ page.locale }}` has been defined.
This change is so that `<html lang="{{ page.lang }}">` can be set to valid language (without territory) information.
  
Closes #375