### PR TITLE
Set the default og:type to 'website'

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -42,6 +42,8 @@
 {% if page.date %}
   <meta property="og:type" content="article" />
   <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
+{% else %}
+  <meta property="og:type" content="website" />
 {% endif %}
 
 {% if paginator.previous_page %}


### PR DESCRIPTION
If the page doesn't have a `date`, `og:type` is not set. This PR attempts to fix that.