### PR TITLE
Fix canonical_url trigger

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -20,7 +20,7 @@
   <meta property="og:description" content="{{ seo_tag.description }}" />
 {% endif %}
 
-{% if site.url %}
+{% if seo_tag.canonical_url %}
   <link rel="canonical" href="{{ seo_tag.canonical_url }}" />
   <meta property="og:url" content="{{ seo_tag.canonical_url }}" />
 {% endif %}


### PR DESCRIPTION
`canonical_url` is inserted in page when `site.url` is set, which has no relation with `canonical_url`. This PR fixes that.