### PR TITLE
Disable other title usage along wit title tag

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -12,6 +12,8 @@ If for some reason, you don't want the plugin to output `<title>` tags on each p
 ```
 <!-- {% endraw %} -->
 
+This will remove output for `<title>`, `<meta property="og:title"/>` and `<meta property="twitter:title"/>`; you can define each of them on your side if needed.
+
 ### Author information
 
 Author information is used to propagate the `creator` field of Twitter summary cards. This should be an author-specific, not site-wide Twitter handle (the site-wide username be stored as `site.twitter.username`).

--- a/lib/template.html
+++ b/lib/template.html
@@ -5,7 +5,7 @@
 
 <meta name="generator" content="Jekyll v{{ jekyll.version }}" />
 
-{% if seo_tag.page_title %}
+{% if seo_tag.page_title and seo_tag.title? %}
   <meta property="og:title" content="{{ seo_tag.page_title }}" />
 {% endif %}
 
@@ -59,7 +59,7 @@
   <meta name="twitter:card" content="summary" />
 {% endif %}
 
-{% if seo_tag.page_title %}
+{% if seo_tag.page_title and seo_tag.title? %}
   <meta property="twitter:title" content="{{ seo_tag.page_title }}" />
 {% endif %}
 


### PR DESCRIPTION
Hi,

I do not know why this disable title option has been added; I'm trying to fix #373.

Problem is my pages titles looks like `pages.home` outputted verbatim in title, and 2 other meta tags. DIsabling title did the trick only for the `<title>` element, my goal is to replace on my side missing metas.

I'm not a ruby developper (been using jekyll for a few days only), and I've not been able to find a solution to override `template.html`; which would have been more interesting perhaps.