### PR TITLE
Fix specs for Jekyll 4.1

### DIFF
--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -219,6 +219,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
 
       context "with a site description" do
         let(:config) { { "description"=> "site description" } }
+        let(:page_meta) { { "excerpt" => "" } }
 
         it "uses the page description" do
           expect(subject.description).to eql("site description")
@@ -226,7 +227,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
 
       context "with no descriptions" do
-        let(:page_meta) { { "description" => nil, "excerpt" => nil } }
+        let(:page_meta) { { "description" => nil, "excerpt" => "" } }
         let(:config) { { "description"=> nil } }
 
         it "uses returns nil" do

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe Jekyll::SeoTag do
 
   context "with site.description" do
     let(:site) { make_site("description" => "foo") }
+    let(:page) { make_page("excerpt" => "") }
 
     it "uses the site description when no page description nor excerpt exist" do
       expect(output).to match(%r!<meta name="description" content="foo" />!)
@@ -292,6 +293,7 @@ RSpec.describe Jekyll::SeoTag do
 
     context "with site.title" do
       let(:site) { make_site("title" => "Foo", "url" => "http://example.invalid") }
+      let(:page) { make_page("excerpt" => "") }
 
       it "outputs the site title meta" do
         expect(output).to match(%r!<meta property="og:site_name" content="Foo" />!)


### PR DESCRIPTION
Specs were not passing with Jekyll 4.1.

The reason:
Jekyll 4.1 introduced a new change in behavior for page.excerpt:
https://github.com/jekyll/jekyll/pull/7642

Related issues:
https://github.com/jekyll/jekyll/issues/8216
https://github.com/jekyll/jekyll-seo-tag/issues/401

How to replicate:
export JEKYLL_VERSION=4.1
bundle update jekyll
./script/cibuild

Output:

```
Failures:

  1) Jekyll::SeoTag::Drop name page description with a site description uses the page description
     Failure/Error: expect(subject.description).to eql("site description")

       expected: "site description"
            got: "Test"

       (compared using eql?)
     # ./spec/jekyll_seo_tag/drop_spec.rb:224:in `block (5 levels) in <top (required)>'

  2) Jekyll::SeoTag::Drop name page description with no descriptions uses returns nil
     Failure/Error: expect(subject.description).to be_nil

       expected: nil
            got: "Test"
     # ./spec/jekyll_seo_tag/drop_spec.rb:233:in `block (5 levels) in <top (required)>'

  3) Jekyll::SeoTag with site.description uses the site description when no page description nor excerpt exist
     Failure/Error: expect(output).to match(%r!<meta name="description" content="foo" />!)

       expected "<!-- Begin Jekyll SEO tag v2.6.1 -->\n<meta name=\"generator\" content=\"Jekyll v4.1.0\" />\n<meta p...,\"@type\":\"WebPage\",\"@context\":\"https://schema.org\"}</script>\n<!-- End Jekyll SEO tag -->\n" to match /<meta name="description" content="foo" \/>/
       Diff:
       @@ -1,2 +1,10 @@
       -/<meta name="description" content="foo" \/>/
       +<!-- Begin Jekyll SEO tag v2.6.1 -->
       +<meta name="generator" content="Jekyll v4.1.0" />
       +<meta property="og:locale" content="en_US" />
       +<meta name="description" content="Test" />
       +<meta property="og:description" content="Test" />
       +<meta name="twitter:card" content="summary" />
       +<script type="application/ld+json">
       +{"url":"/page.html","description":"Test","@type":"WebPage","@context":"https://schema.org"}</script>
       +<!-- End Jekyll SEO tag -->

     # ./spec/jekyll_seo_tag_integration_spec.rb:138:in `block (3 levels) in <top (required)>'

  4) Jekyll::SeoTag with site.url with site.title minifies the output
     Failure/Error: expect(output).to match(expected)

       expected "<!-- Begin Jekyll SEO tag v2.6.1 -->\n<title>Foo</title>\n<meta name=\"generator\" content=\"Jekyll ...,\"@type\":\"WebPage\",\"@context\":\"https://schema.org\"}</script>\n<!-- End Jekyll SEO tag -->\n" to match "<!-- Begin Jekyll SEO tag v2.6.1 -->\n<title>Foo</title>\n<meta name=\"generator\" content=\"Jekyll v4.1.0\" />\n<meta property=\"og:title\" content=\"Foo\" />\n<meta property=\"og:locale\" content=\"en_US\" />\n<link rel=\"canonical\" href=\"http://example.invalid/page.html\" />\n<meta property=\"og:url\" content=\"http://example.invalid/page.html\" />\n<meta property=\"og:site_name\" content=\"Foo\" />\n"
       Diff:

       @@ -3,7 +3,14 @@
        <meta name="generator" content="Jekyll v4.1.0" />
        <meta property="og:title" content="Foo" />
        <meta property="og:locale" content="en_US" />
       +<meta name="description" content="Test" />
       +<meta property="og:description" content="Test" />
        <link rel="canonical" href="http://example.invalid/page.html" />
        <meta property="og:url" content="http://example.invalid/page.html" />
        <meta property="og:site_name" content="Foo" />
       +<meta name="twitter:card" content="summary" />
       +<meta property="twitter:title" content="Foo" />
       +<script type="application/ld+json">
       +{"url":"http://example.invalid/page.html","headline":"Foo","description":"Test","@type":"WebPage","@context":"https://schema.org"}</script>
       +<!-- End Jekyll SEO tag -->

     # ./spec/jekyll_seo_tag_integration_spec.rb:312:in `block (4 levels) in <top (required)>'

Finished in 0.99019 seconds (files took 0.84858 seconds to load)
203 examples, 4 failures

Failed examples:

rspec ./spec/jekyll_seo_tag/drop_spec.rb:223 # Jekyll::SeoTag::Drop name page description with a site description uses the page description
rspec ./spec/jekyll_seo_tag/drop_spec.rb:232 # Jekyll::SeoTag::Drop name page description with no descriptions uses returns nil
rspec ./spec/jekyll_seo_tag_integration_spec.rb:137 # Jekyll::SeoTag with site.description uses the site description when no page description nor excerpt exist
rspec ./spec/jekyll_seo_tag_integration_spec.rb:300 # Jekyll::SeoTag with site.url with site.title minifies the output

```