### PR TITLE
Rename Google webmaster tools to Google Search Console 

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -98,7 +98,7 @@ image:
 
 ### Setting a default image
 
-You can define a default image using [Front Matter default](https://jekyllrb.com/docs/configuration/#front-matter-defaults), to provide a default Twitter Card or OGP image to all of your posts and pages.
+You can define a default image using [Front Matter defaults](https://jekyllrb.com/docs/configuration/front-matter-defaults/), to provide a default Twitter Card or OGP image to all of your posts and pages.
 
 Here is a very basic example, that you are encouraged to adapt to your needs:
 
@@ -112,11 +112,11 @@ defaults:
 
 ### SmartyPants Titles
 
-Titles will be processed using [Jekyll's `smartify` filter](https://jekyllrb.com/docs/templates/). This will use SmartyPants to translate plain ASCII punctuation into "smart" typographic punctuation. This will not render or strip any Markdown you may be using in a page title.
+Titles will be processed using [Jekyll's `smartify` filter](https://jekyllrb.com/docs/liquid/filters/). This will use SmartyPants to translate plain ASCII punctuation into "smart" typographic punctuation. This will not render or strip any Markdown you may be using in a page title.
 
 ### Setting customized Canonical URL
 
-You can set custom Canonical URL for a page by specifying canonical_url option in page front-matter.
+You can set custom Canonical URL for a page by specifying canonical_url option in page front matter.
 E.g., you have the following in the page's front matter:
 ```yml
 layout: post
@@ -130,7 +130,7 @@ Which will generate canonical_url with specified link in canonical_url.
 ```
 
 If no canonical_url option was specified, then uses page url for generating canonical_url.
-E.g., you have not specified canonical_url in front-matter:
+E.g., you have not specified canonical_url in front matter:
 ```yml
 layout: post
 title: Title of Your Post

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,8 +32,8 @@ The SEO tag will respect any of the following if included in your site's `_confi
     admins: 1234
   ```
 
-* `logo` - URL to a site-wide logo (e.g., `/assets/your-company-logo.png`) - If you would like the "publisher" property to be present, you must add this field to your site's configuration, during the validation of the structured data by Google web master tools, if the `logo` field is not validated, you will find errors inherent to the publisher in the [structured datas test](https://search.google.com/structured-data/testing-tool/u/0/)
-* `social` - For [specifying social profiles](https://developers.google.com/structured-data/customize/social-profiles). The following properties are available:
+* `logo` - URL to a site-wide logo (e.g., `/assets/your-company-logo.png`) - If you would like the "publisher" property to be present, you must add this field to your site's configuration, during the validation of the structured data by Google Search Console, if the `logo` field is not validated, you will find errors inherent to the publisher in the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/)
+* `social` - For [specifying social profiles](https://developers.google.com/search/docs/guides/enhance-site#add-your-sites-name-logo-and-social-links). The following properties are available:
   * `name` - If the user or organization name differs from the site's name
   * `links` - An array of links to social media profiles.
 
@@ -48,7 +48,7 @@ The SEO tag will respect any of the following if included in your site's `_confi
       - https://keybase.io/benbalter
   ```
 
-* `google_site_verification` for verifying ownership via Google webmaster tools
+* `google_site_verification` for verifying ownership via Google Search Console
 * Alternatively, verify ownership with several services at once using the following format:
 
 ```yml


### PR DESCRIPTION
- Google webmaster tools no longer exists as it has been renamed to Google Search Console
- Fixed several links 
- Changed front-matter to front matter to be consistent across the docs