### PR TITLE
Force higher version of Travis to use higher version of Jekyll

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
     - JEKYLL_VERSION="~> 3.8"
-    - JEKYLL_VERSION="~> 4.0"
+    - JEKYLL_VERSION="~> 4.1.1"


### PR DESCRIPTION
I created [this issue](https://github.com/jekyll/jekyll-seo-tag/issues/394) a while ago because I learned that the newest version of Jekyll had broken the tests on this repository. Now Jekyll has released a new version, but we still should force Travis to test with Jekyll versions that are at least 4.1.1 (not 4.1.0).