### PR TITLE
Fix Travis builds for Jekyll 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
-    - JEKYLL_VERSION="~> 3.8"
+    - JEKYLL_VERSION="~> 3.9"
     - JEKYLL_VERSION="~> 4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
+gem "kramdown-parser-gfm" if ENV["JEKYLL_VERSION"] == "~> 3.9"


### PR DESCRIPTION
Jekyll 3.9 requires gem `kramdown-parser-gfm` to be additionally made available in the environment.