### PR TITLE
Mutate hash literals instead of duplicating them

### DIFF
--- a/lib/jekyll-seo-tag/author_drop.rb
+++ b/lib/jekyll-seo-tag/author_drop.rb
@@ -78,7 +78,7 @@ module Jekyll
           if resolved_author.is_a? Hash
             resolved_author
           elsif resolved_author.is_a? String
-            { "name" => resolved_author }.merge(site_data_hash)
+            { "name" => resolved_author }.merge!(site_data_hash)
           else
             {}
           end

--- a/lib/jekyll-seo-tag/image_drop.rb
+++ b/lib/jekyll-seo-tag/image_drop.rb
@@ -39,13 +39,17 @@ module Jekyll
 
       # The normalized image hash with a `path` key (which may be nil)
       def image_hash
-        @image_hash ||= if page["image"].is_a?(Hash)
-                          { "path" => nil }.merge(page["image"])
-                        elsif page["image"].is_a?(String)
-                          { "path" => page["image"] }
-                        else
-                          { "path" => nil }
-                        end
+        @image_hash ||= begin
+          image_meta = page["image"]
+
+          if image_meta.is_a?(Hash)
+            { "path" => nil }.merge!(image_meta)
+          elsif image_meta.is_a?(String)
+            { "path" => image_meta }
+          else
+            { "path" => nil }
+          end
+        end
       end
       alias_method :fallback_data, :image_hash
 


### PR DESCRIPTION
Prefer `Hash#merge!` over `Hash#merge` for temporary Hashes.
*At a micro-level, the mutating method [is faster](https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hashmerge-code) as well.*

Additionally, stash `page["image"]` in a local variable in `ImageDrop` so as to reduce calls to `Jekyll::Drops::DocumentDrop#[]`