### PR TITLE
Mutate site payload instead of duplicating it

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -47,12 +47,11 @@ module Jekyll
 
     def payload
       # site_payload is an instance of UnifiedPayloadDrop. See https://git.io/v5ajm
-      Jekyll::Utils.deep_merge_hashes!(
-        context.registers[:site].site_payload,
-        "page"      => context.registers[:page],
-        "paginator" => context["paginator"],
-        "seo_tag"   => drop
-      )
+      context.registers[:site].site_payload.tap do |site_payload|
+        site_payload["page"]      = context.registers[:page]
+        site_payload["paginator"] = context["paginator"]
+        site_payload["seo_tag"]   = drop
+      end
     end
 
     def drop

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -47,7 +47,7 @@ module Jekyll
 
     def payload
       # site_payload is an instance of UnifiedPayloadDrop. See https://git.io/v5ajm
-      Jekyll::Utils.deep_merge_hashes(
+      Jekyll::Utils.deep_merge_hashes!(
         context.registers[:site].site_payload,
         "page"      => context.registers[:page],
         "paginator" => context["paginator"],


### PR DESCRIPTION
Because [`site.site_payload` is an unmemoized method](https://github.com/jekyll/jekyll/blob/20abb8f62b5d93ab18b5505616ee694232488d77/lib/jekyll/site.rb#L291-L294)