### PR TITLE
Add option for overriding structured data attributes

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -78,6 +78,7 @@ The following options can be set for any particular page. While the default opti
   * `links` - An array of other URLs that represent the same thing that this page represents. For instance, Jane's bio page might include links to Jane's GitHub and Twitter profiles.
   * `date_modified` - Manually specify the `dateModified` field in the JSON-LD output to override Jekyll's own `dateModified`.
   This field will take **first priority** for the `dateModified` JSON-LD output. This is useful when the file timestamp does not match the true time that the content was modified. A user may also install [Last Modified At](https://github.com/gjtorikian/jekyll-last-modified-at) which will offer an alternative way of providing for the `dateModified` field.
+  * `custom_structured_data` - Override single values in the structured data tree. Merging is recursive so nested attributes can be overridden without overriding the whole tree.
 
 ### Customizing image output
 

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -175,6 +175,10 @@ module Jekyll
         end
       end
 
+      def custom_structured_data
+        page.to_h.dig("seo", "custom_structured_data")
+      end
+
       private
 
       def filters

--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -79,8 +79,22 @@ module Jekyll
       alias_method :mainEntityOfPage, :main_entity
       private :main_entity
 
+      private def deep_merge(this_hash, other_hash)
+        this_hash.merge(other_hash) do |_key, this_val, other_val|
+          if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+            deep_merge(this_val, other_val)
+          else
+            other_val
+          end
+        end
+      end
+
       def to_json
-        to_h.reject { |_k, v| v.nil? }.to_json
+        drop_hash = to_h
+        if page_drop.custom_structured_data.is_a? Hash
+          drop_hash = deep_merge(drop_hash, page_drop.custom_structured_data)
+        end
+        drop_hash.reject { |_k, v| v.nil? }.to_json
       end
 
       private

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -517,4 +517,25 @@ RSpec.describe Jekyll::SeoTag::Drop do
   it "exposes the JSON-LD drop" do
     expect(subject.json_ld).to be_a(Jekyll::SeoTag::JSONLDDrop)
   end
+
+  context "custom structured data" do
+    context "when specified for a page" do
+      let(:page_meta) do
+        { "seo" => { "custom_structured_data" => {
+          "@type"               => "SoftwareApplication",
+          "applicationCategory" => "Game",
+        } } }
+      end
+
+      it "finds specified structured data" do
+        expect(subject.custom_structured_data).to eq(page_meta["seo"]["custom_structured_data"])
+      end
+    end
+
+    context "when not specified for a page" do
+      it "uses default" do
+        expect(subject.custom_structured_data).to be nil
+      end
+    end
+  end
 end

--- a/spec/jekyll_seo_tag/json_ld_drop_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_drop_spec.rb
@@ -3,6 +3,13 @@
 RSpec.describe Jekyll::SeoTag::JSONLDDrop do
   let(:author) { "author" }
   let(:image) { "image" }
+  let(:seo) do
+    {
+      "name"          => "seo name",
+      "date_modified" => "2017-01-02",
+      "links"         => %w(a b),
+    }
+  end
   let(:metadata) do
     {
       "title"       => "title",
@@ -10,11 +17,7 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
       "image"       => image,
       "date"        => "2017-01-01",
       "description" => "description",
-      "seo"         => {
-        "name"          => "seo name",
-        "date_modified" => "2017-01-02",
-        "links"         => %w(a b),
-      },
+      "seo"         => seo,
     }
   end
   let(:config) do
@@ -158,6 +161,32 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
 
     it "does not return null values as json" do
       expect(subject.to_json).to_not match(%r!:null!)
+    end
+  end
+
+  describe "#to_json" do
+    let(:seo) do
+      {
+        "name"                   => "seo name",
+        "date_modified"          => "2017-01-02",
+        "links"                  => %w(a b),
+        "type"                   => "SoftwareApplication",
+        "custom_structured_data" => {
+          "applicationCategory" => "Game",
+          "name"                => "game name",
+        },
+      }
+    end
+    let(:json_hash) { JSON.parse(subject.to_json) }
+
+    it "merges custom structured data attributes" do
+      expect(json_hash).to have_key("applicationCategory")
+      expect(json_hash["applicationCategory"]).to eq("Game")
+    end
+
+    it "overrides structured data attributes" do
+      expect(json_hash).to have_key("name")
+      expect(json_hash["name"]).to eq("game name")
     end
   end
 end


### PR DESCRIPTION
In the current implementation, only certain attributes can be set for
the structured data. This makes it impossible to use certain types like
"SoftwareApplication", which need unsupported attributes for google to
accept them for rich results. 😖

This change allows the user to override attributes in the structured
data tree by recursively merging in attributes from the
custom_structured_data subtree.