### PR TITLE
This way to a passing Rich Results logo test

### DIFF
--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -84,7 +84,25 @@ module Jekyll
       private :main_entity
 
       def to_json
-        to_h.reject { |_k, v| v.nil? }.to_json
+        # this was what happened before
+        graph = to_h.reject { |_k, v| v.nil? }
+
+        # assign publisher and remove it from the array
+        # (because I don't know the meta-programming involved in instantiating it)
+        publisher = graph["publisher"] || nil
+        graph.delete("publisher")
+
+        updated_graph = {
+          "@context" => "https://schema.org",
+          "@graph"   => [graph],
+        }
+        if publisher
+          # .push({"something" => blah}) === << {"something" => blah}
+          updated_graph["@graph"] << publisher
+        end
+
+        # .to_json for the win
+        updated_graph.to_json
       end
 
       private

--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -63,6 +63,7 @@ module Jekyll
 
         output = {
           "@type" => "Organization",
+          "url"   => page_drop.canonical_url,
           "logo"  => {
             "@type" => "ImageObject",
             "url"   => logo,

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Jekyll::SeoTag do
       let(:site) { make_site("logo" => "/logo.png", "url" => "http://example.invalid") }
 
       it "outputs the logo" do
-        expect(json_data["publisher"]["logo"]["url"]).to eql("http://example.invalid/logo.png")
+        expect(json_data["@graph"][1]["logo"]["url"]).to eql("http://example.invalid/logo.png")
       end
     end
 
@@ -244,7 +244,7 @@ RSpec.describe Jekyll::SeoTag do
       let(:site) { make_site("logo" => "http://cdn.example.invalid/logo.png", "url" => "http://example.invalid") }
 
       it "outputs the logo" do
-        expect(json_data["publisher"]["logo"]["url"]).to eql("http://cdn.example.invalid/logo.png")
+        expect(json_data["@graph"][1]["logo"]["url"]).to eql("http://cdn.example.invalid/logo.png")
       end
     end
 
@@ -252,7 +252,7 @@ RSpec.describe Jekyll::SeoTag do
       let(:site) { make_site("logo" => "http://cdn.example.invalid/logo.png", "url" => "http://example.invalid", "author" => "Mr. Foo") }
 
       it "outputs the author" do
-        expect(json_data["publisher"]["name"]).to eql("Mr. Foo")
+        expect(json_data["@graph"][1]["name"]).to eql("Mr. Foo")
       end
     end
 
@@ -261,12 +261,12 @@ RSpec.describe Jekyll::SeoTag do
       let(:page) { make_post("author" => "Mr. Foo") }
 
       it "outputs the author" do
-        expect(json_data["author"]["@type"]).to eql("Person")
-        expect(json_data["author"]["name"]).to eql("Mr. Foo")
+        expect(json_data["@graph"][0]["author"]["@type"]).to eql("Person")
+        expect(json_data["@graph"][0]["author"]["name"]).to eql("Mr. Foo")
       end
 
       it "outputs the publisher author" do
-        expect(json_data["publisher"]["name"]).to eql("Mr. Foo")
+        expect(json_data["@graph"][1]["name"]).to eql("Mr. Foo")
       end
     end
 
@@ -275,8 +275,8 @@ RSpec.describe Jekyll::SeoTag do
       let(:page) { make_post("seo" => { "type" => "BlogPosting" }, "permalink" => "/foo/") }
 
       it "outputs the mainEntityOfPage" do
-        expect(json_data["mainEntityOfPage"]["@type"]).to eql("WebPage")
-        expect(json_data["mainEntityOfPage"]["@id"]).to eql("http://example.invalid/foo/")
+        expect(json_data["@graph"][0]["mainEntityOfPage"]["@type"]).to eql("WebPage")
+        expect(json_data["@graph"][0]["mainEntityOfPage"]["@id"]).to eql("http://example.invalid/foo/")
       end
     end
 
@@ -285,8 +285,8 @@ RSpec.describe Jekyll::SeoTag do
       let(:page) { make_post("seo" => { "type" => "CreativeWork" }, "permalink" => "/foo/") }
 
       it "outputs the mainEntityOfPage" do
-        expect(json_data["mainEntityOfPage"]["@type"]).to eql("WebPage")
-        expect(json_data["mainEntityOfPage"]["@id"]).to eql("http://example.invalid/foo/")
+        expect(json_data["@graph"][0]["mainEntityOfPage"]["@type"]).to eql("WebPage")
+        expect(json_data["@graph"][0]["mainEntityOfPage"]["@id"]).to eql("http://example.invalid/foo/")
       end
     end
 
@@ -330,9 +330,9 @@ RSpec.describe Jekyll::SeoTag do
         expected = %r!<meta property="og:type" content="article" />!
         expect(output).to match(expected)
 
-        expect(json_data["headline"]).to eql("post")
-        expect(json_data["description"]).to eql("description")
-        expect(json_data["image"]).to eql("http://example.invalid/img.png")
+        expect(json_data["@graph"][0]["headline"]).to eql("post")
+        expect(json_data["@graph"][0]["description"]).to eql("description")
+        expect(json_data["@graph"][0]["image"]).to eql("http://example.invalid/img.png")
       end
 
       it "minifies JSON-LD" do
@@ -551,9 +551,10 @@ RSpec.describe Jekyll::SeoTag do
       end
 
       it "outputs social meta" do
-        expect(json_data["@type"]).to eql("person")
-        expect(json_data["name"]).to eql("Ben")
-        expect(json_data["sameAs"]).to eql(links)
+        # binding.pry
+        expect(json_data["@graph"][0]["@type"]).to eql("person")
+        expect(json_data["@graph"][0]["name"]).to eql("Ben")
+        expect(json_data["@graph"][0]["sameAs"]).to eql(links)
       end
     end
 
@@ -561,7 +562,7 @@ RSpec.describe Jekyll::SeoTag do
       let(:meta) { { "permalink" => "/about/" } }
 
       it "outputs sameAs links" do
-        expect(json_data["sameAs"]).to eql(links)
+        expect(json_data["@graph"][0]["sameAs"]).to eql(links)
       end
     end
 


### PR DESCRIPTION
#### A forward
@ashmaroli Thank you for your patience as I got enough Ruby under my belt to even get this far. I started using `pry` to debug the code in-stream, and it allowed me to even test the output as it was rendered in `rspec`. This is now passing the test on Google, and passing `rspec` and `rubocop`. I don't think my code is great, but it was an attempt. My first! Let's change any/all of it in the hopes that the overall contribution helps this cool open source project.
--Benji

-------

## TL;DR

1. We need a "url" field inside of `"@type" => "Organization"`
2. We need `"@type" => "Organization"` to always be separate from `"@type" => "WebPage"`
3. We need to get it out of `"publisher"`

### We're trying to get a set `logo` to pass a Rich Results test, and there are a few problems.
Google may have changed this, but at the moment it isn't reading things inside of the "publisher" key. As I mentioned in [my open issue](https://github.com/jekyll/jekyll-seo-tag/issues/424) we need to find a way to modify the hash to remove it from `"publisher"` (which [isn't a type property](https://schema.org/publisher) on schema.org anyway).

### My proposal: let's take a look at Yoast, because they do this a lot
Yoast likes to make tons of different `@type` attributes, and house them as an array of objects inside of `@graph`. That's what I'm finding on schema.org, too. So now we want things to look like this:
```JSON
{
  "@context": "https://schema.org",
  "@graph": [
    { "@type": "Organization", },
    { "@type": "WebSite", },
    { "@type": "ImageObject", },
    { "@type": "WebPage", },
  ]
}
```

### I'd rather manipulate the hash than metaprogram
```ruby
def to_json
  # this was what happened before
  graph = to_h.reject { |_k, v| v.nil? }

  # assign publisher and remove it from the array
  # (because I don't know the meta-programming involved in instantiating it)
  publisher = graph["publisher"] || nil
  graph.delete("publisher")

  updated_graph = {
    "@context" => "https://schema.org",
    "@graph"   => [graph],
  }
  if publisher
    # .push({"something" => blah}) === << {"something" => blah}
    updated_graph["@graph"] << publisher
  end

  # .to_json for the win
  updated_graph.to_json
end
```


### Results of the change

Original Output:
```JSON
{
  "@type": "WebPage",
  "publisher": {
    "@type": "Organization",
    "logo": { "@type": "ImageObject", "url": "http://example.invalid/logo.png" }
  },
  "url": "http://example.invalid/page.html",
  "@context": "https://schema.org"
}
```

New Output (confirmed on [Rich Results Test](https://search.google.com/test/rich-results), when you change the canonical url to a valid one):
```JSON
{
  "@context": "https://schema.org",
  "@graph": [
    {
      "@type": "WebPage",
      "url": "http://example.invalid/page.html",
      "@context": "https://schema.org"
    },
    {
      "@type": "Organization",
      "url": "http://example.invalid/page.html",
      "logo": {
        "@type": "ImageObject",
        "url": "http://example.invalid/logo.png"
      }
    }
  ]
}
```