### PR TITLE
Add parameterized title separator

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,6 +11,7 @@ blog dedicated to reviewing cat gifs` that would be used when `page.title` is no
 * `description` - A longer description used for the description meta tag. Also used as fallback for pages that don't
 provide their own `description`, and also as part of the page's title tag if neither `page.title` nor `site.tagline`
 has been defined.
+* `title_separator` - The separator which separates the page title and `title`. Note: ` | ` will be used by default.
 * `url` - The full URL to your site. Note: `site.github.url` will be used by default.
 * `author` - global author information (see [Advanced usage](advanced-usage.md#author-information))
 * `twitter` - The following properties are available:

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -5,7 +5,7 @@ module Jekyll
     class Drop < Jekyll::Drops::Drop
       include Jekyll::SeoTag::UrlHelper
 
-      TITLE_SEPARATOR = " | "
+      TITLE_SEPARATOR = format_string(site["title_separator"] || " | ")
       FORMAT_STRING_METHODS = [
         :markdownify, :strip_html, :normalize_whitespace, :escape_once,
       ].freeze

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -5,7 +5,7 @@ module Jekyll
     class Drop < Jekyll::Drops::Drop
       include Jekyll::SeoTag::UrlHelper
 
-      TITLE_SEPARATOR = format_string(site["title_separator"] || " | ")
+      TITLE_SEPARATOR = " | "
       FORMAT_STRING_METHODS = [
         :markdownify, :strip_html, :normalize_whitespace, :escape_once,
       ].freeze
@@ -57,11 +57,12 @@ module Jekyll
       # Page title with site title or description appended
       # rubocop:disable Metrics/CyclomaticComplexity
       def title
+        @title_separator ||= format_string(site["title_separator"]) || TITLE_SEPARATOR
         @title ||= begin
           if site_title && page_title != site_title
-            page_title + TITLE_SEPARATOR + site_title
+            page_title + @title_separator + site_title
           elsif site_description && site_title
-            site_title + TITLE_SEPARATOR + site_tagline_or_description
+            site_title + @title_separator + site_tagline_or_description
           else
             page_title || site_title
           end

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -5,7 +5,7 @@ module Jekyll
     class Drop < Jekyll::Drops::Drop
       include Jekyll::SeoTag::UrlHelper
 
-      TITLE_SEPARATOR = format_string(site["title_separator"] || " | ")
+      TITLE_SEPARATOR = " | "
       FORMAT_STRING_METHODS = [
         :markdownify, :strip_html, :normalize_whitespace, :escape_once,
       ].freeze
@@ -59,9 +59,9 @@ module Jekyll
       def title
         @title ||= begin
           if site_title && page_title != site_title
-            page_title + TITLE_SEPARATOR + site_title
+            page_title + format_string(site["title_separator"] || TITLE_SEPARATOR) + site_title
           elsif site_description && site_title
-            site_title + TITLE_SEPARATOR + site_tagline_or_description
+            site_title + format_string(site["title_separator"] || TITLE_SEPARATOR) + site_tagline_or_description
           else
             page_title || site_title
           end

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -5,7 +5,7 @@ module Jekyll
     class Drop < Jekyll::Drops::Drop
       include Jekyll::SeoTag::UrlHelper
 
-      TITLE_SEPARATOR = " | "
+      TITLE_SEPARATOR = format_string(site["title_separator"] || " | ")
       FORMAT_STRING_METHODS = [
         :markdownify, :strip_html, :normalize_whitespace, :escape_once,
       ].freeze
@@ -59,9 +59,9 @@ module Jekyll
       def title
         @title ||= begin
           if site_title && page_title != site_title
-            page_title + format_string(site["title_separator"] || TITLE_SEPARATOR) + site_title
+            page_title + TITLE_SEPARATOR + site_title
           elsif site_description && site_title
-            site_title + format_string(site["title_separator"] || TITLE_SEPARATOR) + site_tagline_or_description
+            site_title + TITLE_SEPARATOR + site_tagline_or_description
           else
             page_title || site_title
           end


### PR DESCRIPTION
Adds the ability to declare a custom `title_separator` in the  site's `_config.yml` for separating the page title and the site's title. If omitted the default `" | "` will be used.

Example:

  ```yml
  title_separator: " • "
  ```
