### PR TITLE
Allow to set author url

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -68,6 +68,18 @@ There are several ways to convey this author-specific information. Author inform
   author: benbalter
   ```
 
+#### Setting author url
+
+Starting from August 6, 2021 [Google recommends](https://developers.google.com/search/updates) to set the `author.url` property. This property helps Google to disambiguate the correct author of the article.
+
+You can set it the same way as the other author properties. For example, you can put it in an `author` object, in the site's `_config.yml`, e.g.:
+
+  ```yml
+  author:
+    name: My Name
+    url: https://example.com/
+  ```
+
 ### Customizing JSON-LD output
 
 The following options can be set for any particular page. While the default options are meant to serve most users in the most common circumstances, there may be situations where more precise control is necessary.

--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -41,10 +41,15 @@ module Jekyll
         author_type = page_drop.author["type"]
         return if author_type && !VALID_AUTHOR_TYPES.include?(author_type)
 
-        {
+        hash = {
           "@type" => author_type || "Person",
           "name"  => page_drop.author["name"],
         }
+
+        author_url = page_drop.author["url"]
+        hash["url"] = author_url if author_url
+
+        hash
       end
 
       def image

--- a/spec/jekyll_seo_tag/json_ld_drop_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_drop_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
         expect(subject["author"]).to be nil
       end
     end
+
+    context "when url is present" do
+      let(:author) { { "name" => "author", "url" => "https://example.com" } }
+
+      it "returns the author with url" do
+        expect(subject).to have_key("author")
+        expect(subject["author"]).to be_a(Hash)
+        expect(subject["author"]).to have_key("url")
+        expect(subject["author"]["url"]).to eql("https://example.com")
+        expect(subject["author"]).to have_key("name")
+        expect(subject["author"]["name"]).to be_a(String)
+        expect(subject["author"]["name"]).to eql("author")
+      end
+    end
   end
 
   context "image" do


### PR DESCRIPTION
Starting from August 6, 2021 [Google recommends](https://developers.google.com/search/updates) to set the `author.url` property. This property helps Google to disambiguate the correct author of the article.

This PR adds the ability to specify the author url together with the other author properties.