### PR TITLE
Template: Remove double new line

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -53,7 +53,6 @@
   <link rel="next" href="{{ paginator.next_page_path | absolute_url }}" />
 {% endif %}
 
-
 {% if seo_tag.image %}
   <meta name="twitter:card" content="{{ page.twitter.card | default: site.twitter.card | default: "summary_large_image" }}" />
   <meta property="twitter:image" content="{{ seo_tag.image.path }}" />


### PR DESCRIPTION
Following https://github.com/jekyll/jekyll-seo-tag/pull/438#discussion_r725032069 this cleans up the non-needed new line. All other groups in this file are separated by one new line.