### PR TITLE
Optimize rendering webmaster verifications

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -12,6 +12,7 @@ module Jekyll
     autoload :UrlHelper,  "jekyll-seo-tag/url_helper"
     autoload :Drop,       "jekyll-seo-tag/drop"
     autoload :Filters,    "jekyll-seo-tag/filters"
+    autoload :Webmaster,  "jekyll-seo-tag/webmaster"
 
     attr_accessor :context
 

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -73,6 +73,10 @@ module Jekyll
       end
       # rubocop:enable Metrics/CyclomaticComplexity
 
+      def webmaster_verifications
+        Webmaster.render(site["webmaster_verifications"])
+      end
+
       def name
         return @name if defined?(@name)
 

--- a/lib/jekyll-seo-tag/webmaster.rb
+++ b/lib/jekyll-seo-tag/webmaster.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class SeoTag
+    class Webmaster
+      META_MAP = {
+        "alexa"    => "alexaVerifyID",
+        "baidu"    => "baidu-site-verification",
+        "bing"     => "msvalidate.01",
+        "facebook" => "facebook-domain-verification",
+        "google"   => "google-site-verification",
+        "yandex"   => "yandex-verification",
+      }.freeze
+      META_KEYS = Set.new(META_MAP.keys).freeze
+      private_constant :META_MAP, :META_KEYS
+
+      def self.render(data)
+        return unless data.is_a?(Hash)
+
+        @render ||= data.map do |key, value|
+          %(<meta name="#{META_MAP[key]}" content="#{value}" />) if META_KEYS.include?(key)
+        end.join("\n")
+      end
+    end
+    private_constant :Webmaster
+  end
+end

--- a/lib/template.html
+++ b/lib/template.html
@@ -88,29 +88,7 @@
 {% endif %}
 
 {% if site.webmaster_verifications %}
-  {% if site.webmaster_verifications.google %}
-    <meta name="google-site-verification" content="{{ site.webmaster_verifications.google }}" />
-  {% endif %}
-
-  {% if site.webmaster_verifications.bing %}
-    <meta name="msvalidate.01" content="{{ site.webmaster_verifications.bing }}" />
-  {% endif %}
-
-  {% if site.webmaster_verifications.alexa %}
-    <meta name="alexaVerifyID" content="{{ site.webmaster_verifications.alexa }}" />
-  {% endif %}
-
-  {% if site.webmaster_verifications.yandex %}
-    <meta name="yandex-verification" content="{{ site.webmaster_verifications.yandex }}" />
-  {% endif %}
-
-  {% if site.webmaster_verifications.baidu %}
-    <meta name="baidu-site-verification" content="{{ site.webmaster_verifications.baidu }}" />
-  {% endif %}
-
-  {% if site.webmaster_verifications.facebook %}
-    <meta name="facebook-domain-verification" content="{{ site.webmaster_verifications.facebook }}" />
-  {% endif %}
+  {{ seo_tag.webmaster_verifications }}
 {% elsif site.google_site_verification %}
   <meta name="google-site-verification" content="{{ site.google_site_verification }}" />
 {% endif %}


### PR DESCRIPTION
Instead of using Liquid control flow to render the same final markup for each page / document in the site, (since the rendered markup *only depends on `site.config["webmaster_verifications"]` which is constant for given build*), use a memoized singleton method to directly generate the markup and consequently pass the same as data for the Liquid template.