### PR TITLE
Sort JSON-LD data by key

### DIFF
--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -92,7 +92,7 @@ module Jekyll
       def to_json(state = nil)
         keys.sort.each_with_object({}) do |(key, _), result|
           v = self[key]
-          result[key] = v if v # don't write if value is nil
+          result[key] = v unless v.nil?
         end.to_json(state)
       end
 

--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -87,8 +87,13 @@ module Jekyll
       alias_method :mainEntityOfPage, :main_entity
       private :main_entity
 
-      def to_json
-        to_h.compact.to_json
+      # Returns a JSON-encoded object containing the JSON-LD data.
+      # Keys are sorted.
+      def to_json(state = nil)
+        keys.sort.each_with_object({}) do |(key, _), result|
+          v = self[key]
+          result[key] = v if v # don't write if value is nil
+        end.to_json(state)
       end
 
       private

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe Jekyll::SeoTag do
     expect(output).to match(%r!Jekyll v#{version}!i)
   end
 
+  it "outputs JSON sorted by key" do
+    expect(json.strip).to eql('{"@context":"https://schema.org","@type":"WebPage","url":"/page.html"}')
+  end
+
   it "outputs valid HTML" do
     site.process
     options = {


### PR DESCRIPTION
Deterministic output is desired to improve diffability between builds.
If the output randomly changes order each time it's built, then every
page on a given site will change with every Jekyll build. Tools like
rsync and git which can diff files will always show a change even when
the content hasn't truly changed.

Fixes #362. Fixes #436.