### PR TITLE
Add Ruby 3.1 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
         ruby_version:
         - 2.5
         - 2.7
-        - 3.0
+        - '3.0'
+        - 3.1
         jekyll_version:
         - "~> 4.0"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         ruby_version:
         - 2.5
         - 2.7
-        - '3.0'
         - 3.1
         jekyll_version:
         - "~> 4.0"


### PR DESCRIPTION
Adds Ruby 3.1 to the CI matrix.  Passes on my fork.

Also quotes 3.0 so it isn't truncated to 3.  Because of this truncation, an unquoted 3.0 loads the latest Ruby 3 - at this time 3.1.0 - as opposed to a 3.0.x version.  Adding quotes resolves this issue.