### PR TITLE
chore: remove git.io

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -46,7 +46,7 @@ module Jekyll
     end
 
     def payload
-      # site_payload is an instance of UnifiedPayloadDrop. See https://git.io/v5ajm
+      # site_payload is an instance of UnifiedPayloadDrop. See https://github.com/jekyll/jekyll/blob/22f2724a1f117a94cc16d18c499a93d5915ede4f/lib/jekyll/site.rb#L261-L276
       context.registers[:site].site_payload.tap do |site_payload|
         site_payload["page"]      = context.registers[:page]
         site_payload["paginator"] = context["paginator"]


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/