### PR TITLE
Support for image paths relative to the page's directory

### DIFF
--- a/lib/jekyll-seo-tag/image_drop.rb
+++ b/lib/jekyll-seo-tag/image_drop.rb
@@ -61,13 +61,17 @@ module Jekyll
 
       def absolute_url
         return unless raw_path
-        return @absolute_url if defined? @absolute_url
+        @absolute_url ||= build_absolute_path
+      end
 
-        @absolute_url = if raw_path.is_a?(String) && absolute_url?(raw_path) == false
-                          filters.absolute_url raw_path
-                        else
-                          raw_path
-                        end
+      def build_absolute_path
+        return raw_path unless raw_path.is_a?(String) && absolute_url?(raw_path) == false
+
+        if !raw_path.start_with?("/")
+          return filters.absolute_url File.join(File.dirname(context.registers[:page]["url"]), raw_path)
+        end
+
+        filters.absolute_url raw_path
       end
 
       def filters

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
   end
 
   context "image" do
-    let(:image) { "foo.png" }
+    let(:image) { "/foo.png" }
     let(:page_meta) { { "image" => image } }
 
     it "returns a Drop" do

--- a/spec/jekyll_seo_tag/image_drop_spec.rb
+++ b/spec/jekyll_seo_tag/image_drop_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Jekyll::SeoTag::ImageDrop do
   let(:config)    { { "title" => "site title" } }
   let(:image)     { nil }
-  let(:page_meta) { { "image" => image } }
+  let(:page_meta) { { "image" => image, "dir" => "foo" } }
   let(:page)      { make_page(page_meta) }
   let(:site)      { make_site(config) }
   let(:context)   { make_context(:page => page, :site => site) }
@@ -14,8 +14,24 @@ RSpec.describe Jekyll::SeoTag::ImageDrop do
     Jekyll.logger.log_level = :error
   end
 
-  context "with image as a string" do
+  context "with image as a relative path" do
     let(:image) { "image.png" }
+
+    it "returns the image with the page dir prepended" do
+      expect(subject["path"]).to eql("/foo/image.png")
+    end
+
+    context "with site.url" do
+      let(:config) { { "url" => "http://example.com" } }
+
+      it "makes the path absolute" do
+        expect(subject["path"]).to eql("http://example.com/foo/image.png")
+      end
+    end
+  end
+
+  context "with image as an absolute path" do
+    let(:image) { "/image.png" }
 
     it "returns the image" do
       expect(subject["path"]).to eql("/image.png")
@@ -30,7 +46,7 @@ RSpec.describe Jekyll::SeoTag::ImageDrop do
     end
 
     context "with a URL-escaped path" do
-      let(:image) { "some image.png" }
+      let(:image) { "/some image.png" }
 
       it "URL-escapes the image" do
         expect(subject["path"]).to eql("/some%20image.png")
@@ -39,8 +55,8 @@ RSpec.describe Jekyll::SeoTag::ImageDrop do
   end
 
   context "with image as a hash" do
-    context "with a path" do
-      let(:image) { { "path" => "image.png" } }
+    context "with an absolute path" do
+      let(:image) { { "path" => "/image.png" } }
 
       it "returns the image" do
         expect(subject["path"]).to eql("/image.png")
@@ -48,7 +64,7 @@ RSpec.describe Jekyll::SeoTag::ImageDrop do
     end
 
     context "with facebook" do
-      let(:image) { { "facebook" => "image.png" } }
+      let(:image) { { "facebook" => "/image.png" } }
 
       it "returns the image" do
         expect(subject["path"]).to eql("/image.png")
@@ -56,7 +72,7 @@ RSpec.describe Jekyll::SeoTag::ImageDrop do
     end
 
     context "with twitter" do
-      let(:image) { { "twitter" => "image.png" } }
+      let(:image) { { "twitter" => "/image.png" } }
 
       it "returns the image" do
         expect(subject["path"]).to eql("/image.png")

--- a/spec/jekyll_seo_tag/image_drop_spec.rb
+++ b/spec/jekyll_seo_tag/image_drop_spec.rb
@@ -3,7 +3,13 @@
 RSpec.describe Jekyll::SeoTag::ImageDrop do
   let(:config)    { { "title" => "site title" } }
   let(:image)     { nil }
-  let(:page_meta) { { "image" => image, "dir" => "foo" } }
+  let(:page_meta) do
+    {
+      "image" => image,
+      "dir"   => "foo",
+      "date"  => "2017-01-01"
+    }
+  end
   let(:page)      { make_page(page_meta) }
   let(:site)      { make_site(config) }
   let(:context)   { make_context(:page => page, :site => site) }
@@ -19,7 +25,7 @@ RSpec.describe Jekyll::SeoTag::ImageDrop do
     let(:page) { make_post(page_meta) }
 
     it "returns the image url relative to the post directory" do
-      expect(subject["path"]).to eql("/2022/07/26/image.png")
+      expect(subject["path"]).to eql("/2017/01/01/image.png")
     end
   end
 

--- a/spec/jekyll_seo_tag/image_drop_spec.rb
+++ b/spec/jekyll_seo_tag/image_drop_spec.rb
@@ -3,13 +3,7 @@
 RSpec.describe Jekyll::SeoTag::ImageDrop do
   let(:config)    { { "title" => "site title" } }
   let(:image)     { nil }
-  let(:page_meta) do
-    {
-      "image" => image,
-      "dir"   => "foo",
-      "date"  => "2017-01-01"
-    }
-  end
+  let(:page_meta) { { "image" => image, "dir" => "foo" } }
   let(:page)      { make_page(page_meta) }
   let(:site)      { make_site(config) }
   let(:context)   { make_context(:page => page, :site => site) }
@@ -22,6 +16,7 @@ RSpec.describe Jekyll::SeoTag::ImageDrop do
 
   context "with a post object" do
     let(:image) { "image.png" }
+    let(:page_meta) { { "image" => image, "date" => "2017-01-01" } }
     let(:page) { make_post(page_meta) }
 
     it "returns the image url relative to the post directory" do

--- a/spec/jekyll_seo_tag/json_ld_drop_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_drop_spec.rb
@@ -113,8 +113,8 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
   end
 
   context "image" do
-    context "with image as a string" do
-      let(:image) { "image" }
+    context "with image as an absolute path" do
+      let(:image) { "/image" }
 
       it "returns the image as a string" do
         expect(subject).to have_key("image")
@@ -124,7 +124,7 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
     end
 
     context "with image as a hash" do
-      let(:image) { { "path" => "image", "height" => 5, "width" => 10 } }
+      let(:image) { { "path" => "/image", "height" => 5, "width" => 10 } }
 
       it "returns the image as a hash" do
         expect(subject).to have_key("image")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ CONFIG_DEFAULTS = {
 }.freeze
 
 def make_page(options = {})
-  page = Jekyll::Page.new site, CONFIG_DEFAULTS["source"], "", "page.md"
+  page = Jekyll::Page.new site, CONFIG_DEFAULTS["source"], options.delete("dir") || "", "page.md"
   page.data = options
   page
 end


### PR DESCRIPTION
My config uses [`permalink: /post/:year/:title/`](https://numi.st/post/2022/travel-uke/) together with [`jekyll-postfiles`](https://github.com/nhoizey/jekyll-postfiles) to keep assets local to their respective posts. This allows me to use simpler image tags in [my Markdown](https://github.com/numist/numi.st/blob/main/_posts/2022-04-21-travel-uke/2022-04-21-travel-uke.md) (`![…](image.jpg)`) when editing and as a consequence my post's images tend to be shipped to [`https://:url/post/:year/:title/image.jpg`](https://numi.st/post/2022/travel-uke/IMG_1232.jpeg).

Pre-#44, it was possible to specify `image: image.jpg` in the front matter and the generated URL would be relative to the post, but now `jekyll-seo` emits `https://:url/:baseurl/image.jpg`, which does not exist. #76 improved things somewhat by reintroducing the ability to link off-site images, but it's still not possible to use post-relative paths.

This PR reintroduces that behaviour while maintaining support for paths relative to the site's `baseurl` when they are prefixed by `"/"`, fixing #461.