### PR TITLE
Updated condition requiring tagline or description

### DIFF
--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -60,7 +60,7 @@ module Jekyll
         @title ||= begin
           if site_title && page_title != site_title
             page_title + TITLE_SEPARATOR + site_title
-          elsif site_description && site_title
+          elsif site_tagline_or_description && site_title
             site_title + TITLE_SEPARATOR + site_tagline_or_description
           else
             page_title || site_title


### PR DESCRIPTION
This PR updates the logic generating titles.

The title property was updated in #356 to prefer tagline instead of description. However, the condition on the `if` just above was not updated, so if `site.description` is not defined, then tagline won't be used.