### PR TITLE
Removed support for meta `author`

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -9,10 +9,6 @@
   <meta property="og:title" content="{{ seo_tag.page_title }}" />
 {% endif %}
 
-{% if seo_tag.author.name %}
-  <meta name="author" content="{{ seo_tag.author.name }}" />
-{% endif %}
-
 <meta property="og:locale" content="{{ seo_tag.page_locale }}" />
 
 {% if seo_tag.description %}


### PR DESCRIPTION
## Summary

Removed `<meta name="author" />` tag

1. `<meta name="author" />` has been dropped back in 2014.
2. `<meta name="author" />` is used incorrectly in the template.

## Further information:
- [Special tags currently supported by Google](https://support.google.com/webmasters/answer/79812?hl=en)
- [Moz on "author" tag, listed under "Bad Metas"](https://moz.com/blog/the-ultimate-guide-to-seo-meta-tags)
- [Google Authorship Markup](https://webmasters.googleblog.com/2011/06/authorship-markup-and-web-search.html)
- [Google Scholar Metadata & the `author` tag](https://www.monperrus.net/martin/accurate+bibliographic+metadata+and+google+scholar )

The correct way to use the `authorship` tag is:
```
<a href="/authorname/archive" rel="author">Author Name</a>
```

or when citing a source:

```
<meta name="citation_title" content="Crystal structure of squid rhodopsin" />
<meta name="citation_publication_date" content="1999" />
<meta name="citation_author" content="Murakami, Midori" />
<meta name="citation_author" content="Kouyama, Tsutomu" />
<meta name="citation_pdf_url" content="crist_struct.pdf" />
```

This is directly related to an outdated pull #363