### PR TITLE
Remove trailing slash from closing tag

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -3,123 +3,123 @@
   <title>{{ seo_tag.title }}</title>
 {% endif %}
 
-<meta name="generator" content="Jekyll v{{ jekyll.version }}" />
+<meta name="generator" content="Jekyll v{{ jekyll.version }}" >
 
 {% if seo_tag.page_title %}
-  <meta property="og:title" content="{{ seo_tag.page_title }}" />
+  <meta property="og:title" content="{{ seo_tag.page_title }}" >
 {% endif %}
 
 {% if seo_tag.author.name %}
-  <meta name="author" content="{{ seo_tag.author.name }}" />
+  <meta name="author" content="{{ seo_tag.author.name }}" >
 {% endif %}
 
-<meta property="og:locale" content="{{ seo_tag.page_locale }}" />
+<meta property="og:locale" content="{{ seo_tag.page_locale }}" >
 
 {% if seo_tag.description %}
-  <meta name="description" content="{{ seo_tag.description }}" />
-  <meta property="og:description" content="{{ seo_tag.description }}" />
-  <meta property="twitter:description" content="{{ seo_tag.description }}" />
+  <meta name="description" content="{{ seo_tag.description }}" >
+  <meta property="og:description" content="{{ seo_tag.description }}" >
+  <meta property="twitter:description" content="{{ seo_tag.description }}" >
 {% endif %}
 
 {% if site.url %}
-  <link rel="canonical" href="{{ seo_tag.canonical_url }}" />
-  <meta property="og:url" content="{{ seo_tag.canonical_url }}" />
+  <link rel="canonical" href="{{ seo_tag.canonical_url }}" >
+  <meta property="og:url" content="{{ seo_tag.canonical_url }}" >
 {% endif %}
 
 {% if seo_tag.site_title %}
-  <meta property="og:site_name" content="{{ seo_tag.site_title }}" />
+  <meta property="og:site_name" content="{{ seo_tag.site_title }}" >
 {% endif %}
 
 {% if seo_tag.image %}
-  <meta property="og:image" content="{{ seo_tag.image.path }}" />
+  <meta property="og:image" content="{{ seo_tag.image.path }}" >
   {% if seo_tag.image.height %}
-    <meta property="og:image:height" content="{{ seo_tag.image.height }}" />
+    <meta property="og:image:height" content="{{ seo_tag.image.height }}" >
   {% endif %}
   {% if seo_tag.image.width %}
-    <meta property="og:image:width" content="{{ seo_tag.image.width }}" />
+    <meta property="og:image:width" content="{{ seo_tag.image.width }}" >
   {% endif %}
   {% if seo_tag.image.alt %}
-    <meta property="og:image:alt" content="{{ seo_tag.image.alt }}" />
+    <meta property="og:image:alt" content="{{ seo_tag.image.alt }}" >
   {% endif %}
 {% endif %}
 
 {% if page.date %}
-  <meta property="og:type" content="article" />
-  <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
+  <meta property="og:type" content="article" >
+  <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" >
 {% else %}
-  <meta property="og:type" content="website" />
+  <meta property="og:type" content="website" >
 {% endif %}
 
 {% if paginator.previous_page %}
-  <link rel="prev" href="{{ paginator.previous_page_path | absolute_url }}" />
+  <link rel="prev" href="{{ paginator.previous_page_path | absolute_url }}" >
 {% endif %}
 {% if paginator.next_page %}
-  <link rel="next" href="{{ paginator.next_page_path | absolute_url }}" />
+  <link rel="next" href="{{ paginator.next_page_path | absolute_url }}" >
 {% endif %}
 
 {% if seo_tag.image %}
-  <meta name="twitter:card" content="{{ page.twitter.card | default: site.twitter.card | default: "summary_large_image" }}" />
-  <meta property="twitter:image" content="{{ seo_tag.image.path }}" />
+  <meta name="twitter:card" content="{{ page.twitter.card | default: site.twitter.card | default: "summary_large_image" }}" >
+  <meta property="twitter:image" content="{{ seo_tag.image.path }}" >
 {% else %}
-  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:card" content="summary" >
 {% endif %}
 
 {% if seo_tag.image.alt %}
-  <meta name="twitter:image:alt" content="{{ seo_tag.image.alt }}" />
+  <meta name="twitter:image:alt" content="{{ seo_tag.image.alt }}" >
 {% endif %}
 
 {% if seo_tag.page_title %}
-  <meta property="twitter:title" content="{{ seo_tag.page_title }}" />
+  <meta property="twitter:title" content="{{ seo_tag.page_title }}" >
 {% endif %}
 
 {% if site.twitter %}
-  <meta name="twitter:site" content="@{{ site.twitter.username | remove:'@' }}" />
+  <meta name="twitter:site" content="@{{ site.twitter.username | remove:'@' }}" >
 
   {% if seo_tag.author.twitter %}
-    <meta name="twitter:creator" content="@{{ seo_tag.author.twitter | remove:'@' }}" />
+    <meta name="twitter:creator" content="@{{ seo_tag.author.twitter | remove:'@' }}" >
   {% endif %}
 {% endif %}
 
 {% if site.facebook %}
   {% if site.facebook.admins %}
-    <meta property="fb:admins" content="{{ site.facebook.admins }}" />
+    <meta property="fb:admins" content="{{ site.facebook.admins }}" >
   {% endif %}
 
   {% if site.facebook.publisher %}
-    <meta property="article:publisher" content="{{ site.facebook.publisher }}" />
+    <meta property="article:publisher" content="{{ site.facebook.publisher }}" >
   {% endif %}
 
   {% if site.facebook.app_id %}
-    <meta property="fb:app_id" content="{{ site.facebook.app_id }}" />
+    <meta property="fb:app_id" content="{{ site.facebook.app_id }}" >
   {% endif %}
 {% endif %}
 
 {% if site.webmaster_verifications %}
   {% if site.webmaster_verifications.google %}
-    <meta name="google-site-verification" content="{{ site.webmaster_verifications.google }}" />
+    <meta name="google-site-verification" content="{{ site.webmaster_verifications.google }}" >
   {% endif %}
 
   {% if site.webmaster_verifications.bing %}
-    <meta name="msvalidate.01" content="{{ site.webmaster_verifications.bing }}" />
+    <meta name="msvalidate.01" content="{{ site.webmaster_verifications.bing }}" >
   {% endif %}
 
   {% if site.webmaster_verifications.alexa %}
-    <meta name="alexaVerifyID" content="{{ site.webmaster_verifications.alexa }}" />
+    <meta name="alexaVerifyID" content="{{ site.webmaster_verifications.alexa }}" >
   {% endif %}
 
   {% if site.webmaster_verifications.yandex %}
-    <meta name="yandex-verification" content="{{ site.webmaster_verifications.yandex }}" />
+    <meta name="yandex-verification" content="{{ site.webmaster_verifications.yandex }}" >
   {% endif %}
 
   {% if site.webmaster_verifications.baidu %}
-    <meta name="baidu-site-verification" content="{{ site.webmaster_verifications.baidu }}" />
+    <meta name="baidu-site-verification" content="{{ site.webmaster_verifications.baidu }}" >
   {% endif %}
 
   {% if site.webmaster_verifications.facebook %}
-    <meta name="facebook-domain-verification" content="{{ site.webmaster_verifications.facebook }}" />
+    <meta name="facebook-domain-verification" content="{{ site.webmaster_verifications.facebook }}" >
   {% endif %}
 {% elsif site.google_site_verification %}
-  <meta name="google-site-verification" content="{{ site.google_site_verification }}" />
+  <meta name="google-site-verification" content="{{ site.google_site_verification }}" >
 {% endif %}
 
 <script type="application/ld+json">


### PR DESCRIPTION
According to https://validator.w3.org trailing slashes like these should not be used:

"_Trailing slash on void elements has no effect and interacts badly with unquoted attribute values_"

It's just an INFO message, but doesn't hurt to adhere to the recommendation I think. Below is an example Screenshot of the results I get when validating a page generated with jekyll and jekyll-seo-tag:

![screenshot](https://user-images.githubusercontent.com/3762382/209950567-87a640e3-8c0b-4e62-b297-a232395394e9.png)

## Test
I tested the changes locally and re-uploaded the generated HTML file to the validator. The w3 validator was happy :)