### PR TITLE
Make the meta generator tag optional

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -3,7 +3,9 @@
   <title>{{ seo_tag.title }}</title>
 {% endif %}
 
+{% unless seo_tag.skip_generator %}
 <meta name="generator" content="Jekyll v{{ jekyll.version }}" />
+{% endif %}
 
 {% if seo_tag.page_title %}
   <meta property="og:title" content="{{ seo_tag.page_title }}" />


### PR DESCRIPTION
Webmasters are able to decide themselves whether they want to include a generate meta HTML tag or not using `seo_tag.skip_generator`.
