### PR TITLE
feat: support distinct seo image and page image

### DIFF
--- a/lib/jekyll-seo-tag/image_drop.rb
+++ b/lib/jekyll-seo-tag/image_drop.rb
@@ -55,7 +55,7 @@ module Jekyll
 
       def raw_path
         @raw_path ||= begin
-          image_hash["path"] || image_hash["facebook"] || image_hash["twitter"]
+          image_hash["twitter"] || image_hash["facebook"] || image_hash["path"]
         end
       end
 

--- a/lib/jekyll-seo-tag/version.rb
+++ b/lib/jekyll-seo-tag/version.rb
@@ -5,6 +5,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class SeoTag < Liquid::Tag
-    VERSION = "2.8.0"
+    VERSION = "2.8.1"
   end
 end


### PR DESCRIPTION
Allows to have different or same images for rendering on the top page and for inside meta header when sharing link.

- If image.twitter or image.facebook is present than they will be used to generate og:image and twitter:image of SEO HEAD.
- Otherwise if only image or image:path present - than it will be present on both page image and seo tags.