### PR TITLE
Add a article:modified_time property for articles

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -110,7 +110,7 @@ The following options can be set for any particular page. While the default opti
   * `type` - The type of things that the page represents. This must be a [Schema.org type](https://schema.org/docs/schemas.html), and will probably usually be something like [`BlogPosting`](https://schema.org/BlogPosting), [`NewsArticle`](https://schema.org/NewsArticle), [`Person`](https://schema.org/Person), [`Organization`](https://schema.org/Organization), etc.
   * `links` - An array of other URLs that represent the same thing that this page represents. For instance, Jane's bio page might include links to Jane's GitHub and Twitter profiles.
   * `date_modified` - Manually specify the `dateModified` field in the JSON-LD output to override Jekyll's own `dateModified`.
-  This field will take **first priority** for the `dateModified` JSON-LD output. This is useful when the file timestamp does not match the true time that the content was modified. A user may also install [Last Modified At](https://github.com/gjtorikian/jekyll-last-modified-at) which will offer an alternative way of providing for the `dateModified` field.
+  This field will take **first priority** for the `dateModified` JSON-LD output and the article modification time for Open Graph (`article:modified_time`). This is useful when the file timestamp does not match the true time that the content was modified. A user may also install [Last Modified At](https://github.com/gjtorikian/jekyll-last-modified-at) which will offer an alternative way of providing for the `dateModified` field.
 
 ### Customizing image output
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -42,9 +42,12 @@
   {% endif %}
 {% endif %}
 
-{% if page.date %}
+{% if seo_tag.date_published %}
   <meta property="og:type" content="article" />
-  <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
+  <meta property="article:published_time" content="{{ seo_tag.date_published | date_to_xmlschema }}" />
+  {% if seo_tag.date_modified %}
+    <meta property="article:modified_time" content="{{ seo_tag.date_modified | date_to_xmlschema }}" />
+  {% endif %}
 {% else %}
   <meta property="og:type" content="website" />
 {% endif %}


### PR DESCRIPTION
This PR adds support for `article:modified_time` meta property, utilizing the same `seo_tag` drop values as JSON-LD does.

Two other PRs adding this feature (#447 and #505) are also open, but my attempt has the following advantages:
1. `seo_tag` drop values are used for complete consistency with the JSON-LD output. This ensures compatibility with both`page.last_modified_at` and `seo.date_modified` front matter attributes. I also extended this to the published date instead of using `page.date` directly.
2. Updated the Advanced Usage docs to mention that `seo.date_modified` also influences this new meta property.

Verified working using my own website - on a test blog post, I can see a new meta property added:
```
<meta property="og:type" content="article" />
<meta property="article:published_time" content="2025-04-23T15:30:00+02:00" />
<meta property="article:modified_time" content="2025-04-23T15:30:00+02:00" />
```

The behaviour of adding the modification time even if it equals the publishing time matches [jekyll-feed](https://github.com/jekyll/jekyll-feed).