### PR TITLE
Bump versions in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         ruby_version:
         - 2.5
-        - 3.2
         - 3.3
         - 3.4
         jekyll_version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,13 @@ jobs:
       matrix:
         ruby_version:
         - 2.5
-        - 2.7
-        - 3.1
+        - 3.2
+        - 3.3
+        - 3.4
         jekyll_version:
         - "~> 4.0"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
       - name: "Set up Ruby ${{ matrix.ruby_version }}"
@@ -49,7 +50,7 @@ jobs:
         jekyll_version:
         - "~> 3.9"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
       - name: "Set up Ruby ${{ matrix.ruby_version }}"
@@ -70,7 +71,7 @@ jobs:
         ruby_version:
         - 2.5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
       - name: "Set up Ruby ${{ matrix.ruby_version }}"
@@ -91,7 +92,7 @@ jobs:
         ruby_version:
         - 2.5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
       - name: "Set up Ruby ${{ matrix.ruby_version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-        - 2.5
+        - 2.7
         - 3.3
         - 3.4
         jekyll_version:
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-        - 2.5
+        - 2.7
         jekyll_version:
         - "~> 3.9"
     steps:
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-        - 2.5
+        - 2.7
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-        - 2.5
+        - 2.7
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         ruby_version:
-          - 3.2
+          - 2.7
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: true
       matrix:
         ruby_version:
-          - 2.7
+          - 3.2
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Set up Ruby ${{ matrix.ruby_version }}"
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - 3.2
+          - 2.7
         jekyll_version:
           - "~> 4.0"
           - "~> 3.9"

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - 2.7
+          - 3.2
         jekyll_version:
           - "~> 4.0"
           - "~> 3.9"
@@ -27,18 +27,18 @@ jobs:
       JEKYLL_VERSION: ${{ matrix.jekyll_version }}
     steps:
     - name: Checkout Jekyll SEO Tag
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 5
         path: jekyll-seo-tag
     - name: Checkout Third-Party Repository (WITHOUT SEO Tag)
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ashmaroli/tomjoht.github.io
         ref: "no-seo-tag"
         path: alpha-sandbox
     - name: Checkout Same Third-Party Repository (WITH SEO Tag)
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ashmaroli/tomjoht.github.io
         ref: "seo-tag"


### PR DESCRIPTION
* Update actions/checkout
* Update the Ruby versions matrix to 2.5 (lowest supported) and all currently maintained Ruby versions (3.2-3.4)

I kept 2.5 in the build matrix as it's the lowest supported Ruby version in the `.gemspec` file. I'm not sure if it makes sense to keep 2.7 around, so I instead opted for the currently supported versions. For CI actions that deal with both Jekyll 3.x and 4.x, I opted to use Ruby 3.2 as the oldest currently maintained version, as Jekyll 3.x doesn't work with Ruby 3.4 due to the `base64` dependency no longer being part of the standard library. For tests, I wasn't sure what Ruby version to use so I left it at 2.5.