### PR TITLE
Add support for title_category

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -189,3 +189,24 @@ seo_paginator_message: "%<current>s / %<total>s | "
 
 While the value can be any string text, we recommend using a Ruby string-template containing the variables `current` and `total`
 similar to the example above, to incorporate the current page-number and total number of paginated pages in the title.
+
+### Adding a page title category
+
+You can optionally add a page category to its title.
+This is useful for indicating to the users that some pages are logically grouped or are of a specific kind.
+
+For example page front matter including:
+
+```yml
+title: "my page"
+title_category: "category"
+```
+
+And `_config.yml` including:
+
+```yml
+title: "my site"
+```
+
+Will generate `my page | category | my site` as the page's main `<title>` tag
+and `my page | category` as all other page's title declarations like `og:title`.

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -51,10 +51,10 @@ module Jekyll
 
         title = format_string(page["title"])
         title_category = format_string(page["title_category"])
-        if title && title_category && title != title_category
-          @page_title = title + TITLE_SEPARATOR + title_category
+        @page_title = if title && title_category && title != title_category
+          title + TITLE_SEPARATOR + title_category
         else
-          @page_title = title || title_category || site_title
+          title || title_category || site_title
         end
       end
 

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -47,14 +47,14 @@ module Jekyll
 
       # Page title without site title or description appended
       def page_title
-        @page_title ||= begin
-          title = format_string(page["title"])
-          title_category = format_string(page["title_category"])
-          if title && title_category && title != title_category
-            title + TITLE_SEPARATOR + title_category
-          else
-            title || title_category || site_title
-          end
+        return @page_title if defined?(@page_title)
+
+        title = format_string(page["title"])
+        title_category = format_string(page["title_category"])
+        if title && title_category && title != title_category
+          @page_title = title + TITLE_SEPARATOR + title_category
+        else
+          @page_title = title || title_category || site_title
         end
       end
 

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -47,7 +47,15 @@ module Jekyll
 
       # Page title without site title or description appended
       def page_title
-        @page_title ||= format_string(page["title"]) || site_title
+        @page_title ||= begin
+          title = format_string(page["title"])
+          title_category = format_string(page["title_category"])
+          if title && title_category && title != title_category
+            title + TITLE_SEPARATOR + title_category
+          else
+            title || title_category || site_title
+          end
+        end
       end
 
       def site_tagline_or_description

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -73,6 +73,30 @@ RSpec.describe Jekyll::SeoTag::Drop do
         end
       end
 
+      context "with a page title, page title category and site title" do
+        let(:page) { make_page("title" => "page title", "title_category" => "page title category") }
+
+        it "builds the title" do
+          expect(subject.title).to eql("page title | page title category | site title")
+        end
+      end
+
+      context "with a page title category and site title" do
+        let(:page) { make_page("title_category" => "page title category") }
+
+        it "builds the title" do
+          expect(subject.title).to eql("page title category | site title")
+        end
+      end
+
+      context "with a page title, identical page title category and site title" do
+        let(:page) { make_page("title" => "page title", "title_category" => "page title") }
+
+        it "builds the title" do
+          expect(subject.title).to eql("page title | site title")
+        end
+      end
+
       context "with a site description but no page title" do
         let(:page)  { make_page }
         let(:config) do


### PR DESCRIPTION
This PR is best described by the diff of the changes to `docs/advanced-usage.md` it includes.

Personally I need it for a website that serves multiple longer texts divided into pages, like books divided into chapters. The currently generated `<title>` and title SEO tags just aren't enough, they are lacking the crucial indication that some pages are parts of larger entities, but smaller than the entire website. I also think that it will be useful for other structured texts like documentations where the context of each page is important.