### PR TITLE
Allow disabling json-ld output

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -105,6 +105,7 @@ defaults:
 
 The following options can be set for any particular page. While the default options are meant to serve most users in the most common circumstances, there may be situations where more precise control is necessary.
 
+* `no_json_ld` - If set to `true`, disables `json_ld` output for the page
 * `seo`
   * `name` - If the name of the thing that the page represents is different from the page title. (i.e.: "Frank's Café" vs "Welcome to Frank's Café")
   * `type` - The type of things that the page represents. This must be a [Schema.org type](https://schema.org/docs/schemas.html), and will probably usually be something like [`BlogPosting`](https://schema.org/BlogPosting), [`NewsArticle`](https://schema.org/NewsArticle), [`Person`](https://schema.org/Person), [`Organization`](https://schema.org/Organization), etc.

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -101,7 +101,7 @@ module Jekyll
 
       # A drop representing the JSON-LD output
       def json_ld
-        @json_ld ||= JSONLDDrop.new(self)
+        @json_ld ||= JSONLDDrop.new(self) unless page["no_json_ld"]
       end
 
       # Returns a Drop representing the page's image

--- a/lib/template.html
+++ b/lib/template.html
@@ -122,8 +122,10 @@
   <meta name="google-site-verification" content="{{ site.google_site_verification }}" />
 {% endif %}
 
+{% if seo_tag.json_ld %}
 <script type="application/ld+json">
   {{ seo_tag.json_ld | jsonify }}
 </script>
+{% endif %}
 
 <!-- End Jekyll SEO tag -->


### PR DESCRIPTION
Closes or addresses #473, #135, #503.

Linked issues give background on why this might be a useful feature to have.

Personally I prefer to use Structured Date instead of JSON-LD since it is easier to configure using templates and it is still supported by Google and some other search engines.